### PR TITLE
Add Science academicSubjectDescriptor

### DIFF
--- a/assessments/NWEA_Map/templates/assessments.jsont
+++ b/assessments/NWEA_Map/templates/assessments.jsont
@@ -53,6 +53,9 @@
     },
     {
       "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#Reading"
+    },
+    {
+      "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#Science"
     }
   ],
   "scores": [


### PR DESCRIPTION
Because NWEA MAP is multi-subject, the assessment records still get correctly mapped to the single raw NWEA MAP record upon loading into the ODS. This is why the science studentAssessment records make it in. But a NWEA MAP Science record isn't created in dim_assessment. Therefore, the NWEA MAP Science fct_student_assessment records get mapped to a nonexistent k_assessment.