### PR TITLE
Feature/psat cross test scores

### DIFF
--- a/assessments/PSAT_SAT/earthmover.yml
+++ b/assessments/PSAT_SAT/earthmover.yml
@@ -74,6 +74,8 @@ transformations:
           LATEST_{{test}}_ENG_CONVENT: standard_english_conventions_subscore
           LATEST_{{test}}_HEART_ALGEBRA: heart_of_algebra_subscore
           LATEST_{{test}}_PROBSLV_DATA: problem_solving_and_data_analysis_subscore
+          LATEST_{{test}}_SCI_CROSS: analysis_in_science_xtest_score
+          LATEST_{{test}}_HIST_SOCST_CROSS: analysis_in_history_xtest_score
           PERCENTILE_NATREP_{{test}}_TOTAL: nationally_representative_total_score
           PERCENTILE_NATREP_{{test}}_EBRW: nationally_representative_reading_writing_section_score
           PERCENTILE_NATREP_{{test}}_MATH_SECTION: nationally_representative_math_section_score

--- a/assessments/PSAT_SAT/lightbeam.yml
+++ b/assessments/PSAT_SAT/lightbeam.yml
@@ -1,12 +1,12 @@
 verbose: True
 data_dir: ${DATA_DIR}
 edfi_api:
-  base_url: ${BASE_URL}
+  base_url: ${EDFI_API_BASE_URL}
   version: 3
   mode: district_specific
   year: ${API_YEAR}
-  client_id: ${CLIENT_ID}
-  client_secret: ${CLIENT_SECRET}
+  client_id: ${EDFI_API_CLIENT_ID}
+  client_secret: ${EDFI_API_CLIENT_SECRET}
 connection:
   pool_size: 8
   timeout: 60

--- a/assessments/PSAT_SAT/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/PSAT_SAT/seeds/assessmentReportingMethodDescriptors.csv
@@ -30,4 +30,6 @@ User Percentile Subscore,User Percentile Subscore,uri://collegeboard.org/Assessm
 Essay Reading Subscore,Essay Reading Subscore,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Essay Reading Subscore
 Essay Writing Subscore,Essay Writing Subscore,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Essay Writing Subscore
 Essay Analysis Subscore,Essay Analysis Subscore,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Essay Analysis Subscore
+Analysis in Science Cross-Test Score,Analysis in Science Cross-Test Score,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Analysis in Science Cross-Test Score
+Analysis in History Social Sci Cross-Test Score,Analysis in History Social Sci Cross-Test Score,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Analysis in History Social Sci Cross-Test Score
 Subject,Subject,uri://collegeboard.org/AssessmentReportingMethodDescriptor,Subject

--- a/assessments/PSAT_SAT/templates/studentAssessments.jsont
+++ b/assessments/PSAT_SAT/templates/studentAssessments.jsont
@@ -58,6 +58,12 @@
       {% if user_percentile_math_section_score != '' %}
         {% set _= all_scores.append(["User Percentile Section Score", user_percentile_math_section_score]) %}
       {% endif %}
+      {% if analysis_in_science_xtest_score != '' %}
+        {% set _= all_scores.append(["Analysis in Science Cross-Test Score", analysis_in_science_xtest_score]) %}
+      {% endif %}
+      {% if analysis_in_history_xtest_score != '' %}
+        {% set _= all_scores.append(["Analysis in History Social Sci Cross-Test Score", analysis_in_history_xtest_score]) %}
+      {% endif %}
       {% if subject != '' %}
         {% set _= all_scores.append(["Subject", subject]) %}
       {% endif %}


### PR DESCRIPTION
## Description & motivation
Adds the Analysis in History and Social Sciences cross-test scores. These are based on a selection of relevant questions on both the Math and ELA exams, which we are loading as separate student assessments. I added them to the student assessment level for both subjects.

The `lightbeam.yml` variable names also needed to be updated to the standard values used by earthbeam.

## Changes to existing files:
- `earthmover.yml`: rename relevant columns
- `lightbeam.yml`: update variable names to earthbeam standards
- `assessmentReportingMethodDescriptors.csv`: add cross-test subscores
- `studentAssessments.jsont`: add cross-test subscores

## Tests and QC done:
- The subscores were successfully loaded for Denver.

## PR Merge Priority:
Low