### PR TITLE
Bugfix/dibels 8

### DIFF
--- a/assessments/Dibels_8_Benchmark/earthmover.yaml
+++ b/assessments/Dibels_8_Benchmark/earthmover.yaml
@@ -66,7 +66,7 @@ transformations:
     - operation: snake_case_columns
     - operation: add_columns
       columns:
-        student_assessment_id: "{%raw%}{{primary_id_student_id}}_{{client_date}}{%endraw%}"
+        student_assessment_id: "{%raw%}{{primary_id_student_id}}_{{client_date}}_{{assessment_grade}}{%endraw%}"
         assessment_id: "Dibels-8"
     - operation: modify_columns
       columns:

--- a/assessments/Dibels_8_Benchmark/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/Dibels_8_Benchmark/seeds/assessmentReportingMethodDescriptors.csv
@@ -11,3 +11,4 @@ Assessment Measure National Norm Percentile,Assessment Measure National Norm Per
 Assessment Measure Semester Growth,Assessment Measure Semester Growth,uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor,Assessment Measure Semester Growth
 Assessment Measure Year Growth,Assessment Measure Year Growth,uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor,Assessment Measure Year Growth
 Benchmark Period,Benchmark Period,uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor,Benchmark Period
+Risk Indicator,Risk Indicator,uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor,Risk Indicator

--- a/assessments/Dibels_8_Benchmark/seeds/objectiveAssessments.csv
+++ b/assessments/Dibels_8_Benchmark/seeds/objectiveAssessments.csv
@@ -11,4 +11,3 @@ Reading-Comprehension-Maze,Reading Comprehension - Maze
 Vocabulary,Vocabulary
 Spelling,Spelling
 RAN,RAN
-Risk-Indicator,Risk Indicator

--- a/assessments/Dibels_8_Benchmark/seeds/performanceLevelDescriptors.csv
+++ b/assessments/Dibels_8_Benchmark/seeds/performanceLevelDescriptors.csv
@@ -12,3 +12,4 @@ Above Benchmark,Above Benchmark,uri://dibels.uoregon.edu/assessment/dibels/Perfo
 At Risk,At Risk,uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor,At Risk
 Low Risk,Low Risk,uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor,Low Risk
 Not Determined,Not Determined,uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor,Not Determined
+Tested Out,Tested Out,uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor,Tested Out

--- a/assessments/Dibels_8_Benchmark/templates/assessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/assessments.jsont
@@ -1,6 +1,6 @@
 {
   "assessmentIdentifier": "{{assessment_id}}",
-  "assessmentTitle": "Dibels 8th Edition",
+  "assessmentTitle": "DIBELS 8th Edition",
   "namespace": "uri://dibels.uoregon.edu/assessment/dibels",
   "assessedGradeLevels": [
     {

--- a/assessments/Dibels_8_Benchmark/templates/assessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/assessments.jsont
@@ -123,6 +123,16 @@
       "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Composite Level",
       "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Not Determined",
       "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+    },
+    {
+      "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Risk Indicator",
+      "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#At Risk",
+      "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+    },
+    {
+      "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Risk Indicator",
+      "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Low Risk",
+      "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
     }
   ]
 }

--- a/assessments/Dibels_8_Benchmark/templates/objectiveAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/objectiveAssessments.jsont
@@ -75,6 +75,11 @@
         "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
       },
       {
+        "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Assessment Measure Semester Growth",
+        "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Tested Out",
+        "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
         "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Assessment Measure Year Growth",
         "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Well Below Average",
         "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
@@ -97,6 +102,11 @@
       {
         "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Assessment Measure Year Growth",
         "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Well Above Average",
+        "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Assessment Measure Year Growth",
+        "performanceLevelDescriptor":"uri://dibels.uoregon.edu/assessment/dibels/PerformanceLevelDescriptor#Tested Out",
         "resultDatatypeTypeDescriptor":"uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
       }
   ],

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -22,6 +22,9 @@
     {% if composite_year_growth != '' %}
       {% set _= all_pls.append(["Composite Year Growth", composite_year_growth]) %}
     {% endif %}
+    {% if risk_indicator_level != '' %}
+      {% set _= all_pls.append(["Risk Indicator", risk_indicator_level]) %}
+    {% endif %}
   
     {%- for pl in all_pls -%}
     {
@@ -38,7 +41,7 @@
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{composite_score}}"
     },
-    {% if dibels_composite_national_norm_percentile != '' %}
+    {% if composite_national_norm_percentile != '' %}
     {
       "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Composite National Norm Percentile",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
@@ -51,7 +54,7 @@
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
       "result": "{{dibels_composite_score_lexile}}"
     },
-    {% endif %}
+    {% endif %} 
     {
       "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Benchmark Period",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
@@ -70,8 +73,7 @@
                                   ['Reading-Comprehension-Maze', ['Assessment Measure Level', reading_comprehension_maze_level], ['Assessment Measure Score', reading_comprehension_maze_score], ['Assessment Measure National Norm Percentile', reading_comprehension_maze_national_norm_percentile], ['Assessment Measure Semester Growth', reading_comprehension_maze_semester_growth], ['Assessment Measure Year Growth', reading_comprehension_maze_year_growth]],
                                   ['Vocabulary', ['Assessment Measure Level', vocabulary_level], ['Assessment Measure Score', vocabulary_score]],
                                   ['Spelling', ['Assessment Measure Level', spelling_level], ['Assessment Measure Score', spelling_score]],
-                                  ['RAN', ['Assessment Measure Level', ran_level], ['Assessment Measure Score', ran_score]],
-                                  ['Risk-Indicator', ['Assessment Measure Level', risk_indicator_level]]] %}
+                                  ['RAN', ['Assessment Measure Level', ran_level], ['Assessment Measure Score', ran_score]]] %}
     {% set all_obj_assessment = [] %}
     {%- for obj in possible_obj_assess -%}
       {% if (obj[1]|length > 0 and obj[1][1] != '') or (obj[2] is defined and obj[2][1] != '') %}

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -123,7 +123,7 @@
         ,
         {
           "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[3][0]}}",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
           "result": "{{obj[3][1]}}"
         }
         {% endif %}

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -38,11 +38,13 @@
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{composite_score}}"
     },
+    {% if dibels_composite_national_norm_percentile != '' %}
     {
       "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Composite National Norm Percentile",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{composite_national_norm_percentile}}"
     },
+    {% endif %}
     {% if dibels_composite_score_lexile != '' %}
     {
       "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#Composite Score Lexile",


### PR DESCRIPTION
## Description & motivation
This PR fixes a few issues that were found when we loaded Denver's results file.
 - Add assessed grade level to the grain of the student assessment result
 - The Risk Indicator score on DIBELS 8 was incorrectly categorized as an objective assessment. It should be a performance level on the student assessment. 
 - Fix null result handling for objective assessments
 - Fix assessment title capitalization

## Tests and QC done:
Ran successfully in Jeffco and Denver

## PR Merge Priority:
- Low

