### PR TITLE
bugfix/STAR math subject fix

### DIFF
--- a/assessments/Renaissance_STAR/templates/assessments.jsont
+++ b/assessments/Renaissance_STAR/templates/assessments.jsont
@@ -49,7 +49,7 @@
     }
   ],
   "academicSubjects": [
-    {% if assessment_id == 'STAR-SM' %}
+    {% if assessment_id == 'STAR-MA' %}
     {
       "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics"
     }


### PR DESCRIPTION
The assessment ID that determined the academicSubject was wrong for STAR Math, causing it to be labeled a Reading assessment.