### PR TITLE
DIBELS fixes

### DIFF
--- a/assessments/Dibels_8_Benchmark/seeds/grade_mapping.csv
+++ b/assessments/Dibels_8_Benchmark/seeds/grade_mapping.csv
@@ -5,4 +5,4 @@ K,Kindergarten
 3,Third grade
 4,Fourth grade
 5,Fifth grade
-6,Sixth Grade
+6,Sixth grade

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -129,7 +129,7 @@
           {% endif %}
         {% elif obj[3] is defined and obj[3][1] != '' %}
         {
-          "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[2][0]}}",
+          "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[3][0]}}",
           "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
           "result": "{{obj[3][1]}}"
         }

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -132,7 +132,7 @@
           "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[2][0]}}",
           "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
           "result": "{{obj[3][1]}}"
-        },
+        }
         {% endif %}
       ]
     }{%- if not loop.last -%},

--- a/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
+++ b/assessments/Dibels_8_Benchmark/templates/studentAssessments.jsont
@@ -119,14 +119,14 @@
           "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
           "result": "{{obj[2][1]}}"
         }
-        {% if obj[3] is defined and obj[3][1] != '' %}
-        ,
-        {
-          "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[3][0]}}",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
-          "result": "{{obj[3][1]}}"
-        }
-        {% endif %}
+          {% if obj[3] is defined and obj[3][1] != '' %}
+          ,
+          {
+            "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[3][0]}}",
+            "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
+            "result": "{{obj[3][1]}}"
+          }
+          {% endif %}
         {% elif obj[3] is defined and obj[3][1] != '' %}
         {
           "assessmentReportingMethodDescriptor": "uri://dibels.uoregon.edu/assessment/dibels/AssessmentReportingMethodDescriptor#{{obj[2][0]}}",

--- a/assessments/Lectura/seeds/grade_mapping.csv
+++ b/assessments/Lectura/seeds/grade_mapping.csv
@@ -5,4 +5,4 @@ K,Kindergarten
 3,Third grade
 4,Fourth grade
 5,Fifth grade
-6,Sixth Grade
+6,Sixth grade

--- a/assessments/Lectura/templates/studentAssessments.jsont
+++ b/assessments/Lectura/templates/studentAssessments.jsont
@@ -70,7 +70,7 @@
       "objectiveAssessmentReference": {
         "assessmentIdentifier": "{{assessment_id}}",
         "identificationCode": "{{obj_id}}",
-        "assessment_namespace": "uri://amplify.com/programs/mclass-lectura"
+        "namespace": "uri://amplify.com/programs/mclass-lectura"
       },
       "scoreResults": [
         {% if (obj_names[0] != '') %}
@@ -79,25 +79,25 @@
           "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
           "result": "{{obj_names[0]}}"
         }
-        {% if (obj_names[1] != '') %},
-        {
-          "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Local Percentile",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
-          "result": "{{obj_names[1]}}"
-        }
-        {% endif %}
-        {% if obj_id == 'CP' %},
-        {
-          "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Correct Responses",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
-          "result": "{{correct_responses_cp_score}}"          
-        },
-        {
-          "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Incorrect Responses",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
-          "result": "{{incorrect_responses_cp_score}}"          
-        }
-        {% endif %}
+          {% if (obj_names[1] != '') %},
+          {
+            "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Local Percentile",
+            "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+            "result": "{{obj_names[1]}}"
+          }
+          {% endif %}
+          {% if obj_id == 'CP' %},
+          {
+            "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Correct Responses",
+            "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+            "result": "{{correct_responses_cp_score}}"          
+          },
+          {
+            "assessmentReportingMethodDescriptor": "uri://amplify.com/programs/mclass-lectura/AssessmentReportingMethodDescriptor#Incorrect Responses",
+            "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+            "result": "{{incorrect_responses_cp_score}}"          
+          }
+          {% endif %}
         {% endif %}
         {% if obj_id in ('FEP',  'FLO', 'FLO-Prec') and  obj_names[0] == '' %} 
         {


### PR DESCRIPTION
1. Small descriptor tweak that is necessary when the API is case sensitive - `Sixth Grade` -> `Sixth grade` for both DIBELS8 and Lectura.
2. Remove comma that was creating an extra trailing comma 
3. Fix a typo that would have been grabbing the incorrect field. This is a rare edge case so it hasn't been brought up before. Also, because I indented some lines for readability and the lines are the same as some above it, it looks like the changes are much bigger, but it's just indentation changes.
4. Renamed `assessment_namespace` to `namespace`. Not sure if this was working for other implementations, but the 5.3 api docs are looking for `namespace` here