### PR TITLE
Feature/IB

### DIFF
--- a/assessments/IB/README.md
+++ b/assessments/IB/README.md
@@ -1,0 +1,37 @@
+This is an earthmover bundle created from the following Ed-Fi Data Import Tool mapping:
+* **Title**: International Baccalaureate (IB) Results - API 3.X
+* **Description**: This template maps International Baccalaureate assessment results.
+* **API version**: 5.3
+* **Submitter name**: Samantha LeBlanc
+* **Submitter organization**: Education Analytics
+
+## Note on Student IDs
+The IB results file does not include student IDs besides internal IB candidate IDs. This bundle expects a column called `student_unique_id` to be present in the results file, which will need to be added and populated as a pre-preprocessing step before this bundle can be used.
+
+## CLI Parameters
+
+### Required
+- OUTPUT_DIR: Where output files will be written.
+- BUNDLE_DIR: Parent folder of the bundle, where `earthmover.yaml` lives.
+- INPUT_FILE: The path to the IB .csv file you want to transform.
+- API_YEAR: The API year that the output of this template will be sent to.
+
+### Examples
+Running earthmover for an IB file:
+```bash
+earthmover run -c ./earthmover.yaml -p '{
+"BUNDLE_DIR": ".",
+"INPUT_FILE": "path/to/IB.csv",
+"OUTPUT_DIR": "./output",
+"API_YEAR": "20xx"}'
+```
+
+Once you have inspected the output JSONL for issues, check the settings in `lightbeam.yaml` and transmit them to your Ed-Fi API with
+```bash
+lightbeam validate+send -c ./lightbeam.yaml -p '{
+"DATA_DIR": "./output/",
+"EDFI_API_BASE_URL": "yourURL",
+"EDFI_API_CLIENT_ID": "yourID",
+"EDFI_API_CLIENT_SECRET": "yourSecret",
+"EDFI_API_YEAR": yourAPIYear }'
+```

--- a/assessments/IB/earthmover.yaml
+++ b/assessments/IB/earthmover.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 config:
-  log_level: DEBUG
+  log_level: INFO
   output_dir: ${OUTPUT_DIR}
   memory_limit: 1GB
   state_file: ${STATE_FILE}

--- a/assessments/IB/earthmover.yaml
+++ b/assessments/IB/earthmover.yaml
@@ -1,0 +1,107 @@
+version: 2
+
+config:
+  log_level: DEBUG
+  output_dir: ${OUTPUT_DIR}
+  memory_limit: 1GB
+  state_file: ${STATE_FILE}
+  show_graph: False
+  show_stacktrace: true
+  macros: > 
+      {% macro group_number_with_language(value) -%}
+      {%- if group_number == '1' -%}
+      {%- if language == 'ENGLISH' -%}1 - English
+      {%- else -%}1 - Foreign Language
+      {%- endif -%}
+      {%- else -%}{{group_number}}
+      {%- endif -%}
+      {%- endmacro %}
+
+
+sources:
+  ib_input:
+    file: ${INPUT_FILE}
+    header_rows: 1
+  assessmentReportingMethodDescriptors:
+    file: ${BUNDLE_DIR}/seeds/assessmentReportingMethodDescriptors.csv
+    header_rows: 1
+  performanceLevelDescriptors:
+    file: ${BUNDLE_DIR}/seeds/performanceLevelDescriptors.csv
+    header_rows: 1
+  subject_group_mappings:
+    file: ${BUNDLE_DIR}/seeds/subject_group_mappings.csv
+    header_rows: 1
+
+
+transformations:
+  ib_student_results:
+    source: $sources.ib_input
+    operations:
+      - operation: snake_case_columns
+      - operation: combine_columns
+        columns:
+          - year
+          - month
+          - candidate
+          - subject
+          - level
+        new_column: combined_student_assessment_id
+        separator: '-'
+      - operation: add_columns
+        columns:
+          assessment_identifier: "{%raw%}IB - {{subject}}{%endraw%}"
+          assessment_title: "{%raw%}International Baccalaureate - {{subject}}{%endraw%}"
+          assessment_family: "International Baccalaureate"
+          namespace: "uri://ibo.org"
+          school_year: ${API_YEAR}
+          administration_date: "{%raw%}{{year}}-{%- if month == 'MAY' -%}05{%- else -%}11{%- endif -%}-01{%endraw%}"
+          student_assessment_identifier: "{%raw%}{{ md5(combined_student_assessment_id) }}{%endraw%}" 
+  
+  student_assessments:
+    source: $transformations.ib_student_results
+    operations:
+      - operation: join
+        sources:
+          - $sources.subject_group_mappings
+        join_type: inner
+        left_key: group_number
+        right_key: group_id
+
+  assessments:
+    source: $transformations.ib_student_results
+    operations:
+      - operation: distinct_rows
+        columns: 
+          - subject
+      - operation: add_columns
+        columns:
+          mod_group_number: "{%raw%}{{ group_number_with_language(group_number) }}{%endraw%}"
+      - operation: join
+        sources:
+          - $sources.subject_group_mappings
+        join_type: inner
+        left_key: mod_group_number
+        right_key: group_id
+
+
+destinations:
+  assessments:
+    source: $transformations.assessments
+    template: ${BUNDLE_DIR}/templates/assessments.jsont
+    extension: jsonl
+    linearize: True
+  assessmentReportingMethodDescriptors:
+    source: $sources.assessmentReportingMethodDescriptors
+    template: ${BUNDLE_DIR}/templates/assessmentReportingMethodDescriptors.jsont
+    extension: jsonl
+    linearize: True
+  performanceLevelDescriptors:
+    source: $sources.performanceLevelDescriptors
+    template: ${BUNDLE_DIR}/templates/performanceLevelDescriptors.jsont
+    extension: jsonl
+    linearize: True
+  studentAssessments:
+    source: $transformations.student_assessments
+    template: ${BUNDLE_DIR}/templates/studentAssessments.jsont
+    extension: jsonl
+    linearize: True

--- a/assessments/IB/lightbeam.yaml
+++ b/assessments/IB/lightbeam.yaml
@@ -1,0 +1,18 @@
+state_dir: ${STATE_DIR}
+data_dir: ${DATA_DIR}
+edfi_api:
+  base_url: ${EDFI_API_BASE_URL}
+  version: 3
+  mode: district_specific
+  year: ${API_YEAR}
+  client_id: ${EDFI_API_CLIENT_ID}
+  client_secret: ${EDFI_API_CLIENT_SECRET}
+connection:
+  pool_size: 2
+  timeout: 6000
+  num_retries: 10
+  backoff_factor: 1.5
+  retry_statuses: [429, 500, 502, 503, 504]
+  verify_ssl: True
+log_level: DEBUG
+show_stacktrace: True

--- a/assessments/IB/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/IB/seeds/assessmentReportingMethodDescriptors.csv
@@ -1,0 +1,9 @@
+codeValue,description,namespace,shortDescription
+Category,Indicates whether the student has been awarded a diploma or received individual course results only,uri://ibo.org/AssessmentReportingMethodDescriptor,Category
+Subject Group,Subject Group,uri://ibo.org/AssessmentReportingMethodDescriptor,Subject Group
+Level,Course level,uri://ibo.org/AssessmentReportingMethodDescriptor,Level
+Predicted Grade,Predicted Grade,uri://ibo.org/AssessmentReportingMethodDescriptor,Predicted Grade
+Subject Grade,Subject Grade,uri://ibo.org/AssessmentReportingMethodDescriptor,Subject Grade
+EE/TOK Bonus Points,Diploma Level; a whole number from 1 to 3 awarded based on the combination of letter grades (A to E) received for Extended Essay and Theory of Knowledge,uri://ibo.org/AssessmentReportingMethodDescriptor,EE/TOK Bonus Points
+Total Points,Diploma Level; a whole number from 1 to 45 equal to the sum of all subject grades and EE / TOK points,uri://ibo.org/AssessmentReportingMethodDescriptor,Total Points
+Diploma Result Code,Diploma Level; result code,uri://ibo.org/AssessmentReportingMethodDescriptor,Diploma Result Code

--- a/assessments/IB/seeds/performanceLevelDescriptors.csv
+++ b/assessments/IB/seeds/performanceLevelDescriptors.csv
@@ -1,4 +1,4 @@
 codeValue,description,namespace,shortDescription
-D,D,uri://ibo.org/PerformanceLevelDescriptor,D
-F,F,uri://ibo.org/PerformanceLevelDescriptor,F
-P,P,uri://ibo.org/PerformanceLevelDescriptor,P
+D,The student passed the Diploma program,uri://ibo.org/PerformanceLevelDescriptor,Diploma
+F,The student has not passed the Diploma program and receives course-level results only,uri://ibo.org/PerformanceLevelDescriptor,Course results only
+P,The student's Diploma program results are pending,uri://ibo.org/PerformanceLevelDescriptor,Pending

--- a/assessments/IB/seeds/performanceLevelDescriptors.csv
+++ b/assessments/IB/seeds/performanceLevelDescriptors.csv
@@ -1,0 +1,4 @@
+codeValue,description,namespace,shortDescription
+D,D,uri://ibo.org/PerformanceLevelDescriptor,D
+F,F,uri://ibo.org/PerformanceLevelDescriptor,F
+P,P,uri://ibo.org/PerformanceLevelDescriptor,P

--- a/assessments/IB/seeds/subject_group_mappings.csv
+++ b/assessments/IB/seeds/subject_group_mappings.csv
@@ -1,0 +1,11 @@
+group_id,ib_group_name,edfi_subject
+1,Language and literature,N/A
+1 - English,N/A,English Language Arts
+1 - Foreign Language,N/A,Foreign Language and Literature
+2,Language acquisition,Foreign Language and Literature
+3,Individuals and societies,Social Studies
+3 and 4,Individuals and societies / Science,Cross Subject
+4,Sciences,Science
+5,Mathematics,Mathematics
+6,The arts,Fine and Performing Arts
+9,Core elements,Other

--- a/assessments/IB/seeds/subject_group_mappings.csv
+++ b/assessments/IB/seeds/subject_group_mappings.csv
@@ -1,11 +1,11 @@
 group_id,ib_group_name,edfi_subject
 1,Language and literature,N/A
-1 - English,N/A,English Language Arts
-1 - Foreign Language,N/A,Foreign Language and Literature
-2,Language acquisition,Foreign Language and Literature
-3,Individuals and societies,Social Studies
-3 and 4,Individuals and societies / Science,Cross Subject
-4,Sciences,Science
-5,Mathematics,Mathematics
-6,The arts,Fine and Performing Arts
-9,Core elements,Other
+1 - English,N/A,uri://ed-fi.org/AcademicSubjectDescriptor#English Language Arts
+1 - Foreign Language,N/A,uri://ed-fi.org/AcademicSubjectDescriptor#Foreign Language and Literature
+2,Language acquisition,uri://ed-fi.org/AcademicSubjectDescriptor#Foreign Language and Literature
+3,Individuals and societies,uri://ed-fi.org/AcademicSubjectDescriptor#Social Studies
+3 and 4,Individuals and societies / Science,uri://ed-fi.org/AcademicSubjectDescriptor#Cross Subject
+4,Sciences,uri://ed-fi.org/AcademicSubjectDescriptor#Science
+5,Mathematics,uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics
+6,The arts,uri://ed-fi.org/AcademicSubjectDescriptor#Fine and Performing Arts
+9,Core elements,uri://ed-fi.org/AcademicSubjectDescriptor#Other

--- a/assessments/IB/templates/assessmentReportingMethodDescriptors.jsont
+++ b/assessments/IB/templates/assessmentReportingMethodDescriptors.jsont
@@ -1,0 +1,6 @@
+{
+    "codeValue": "{{codeValue}}",
+    "description": "{{description}}",
+    "namespace": "{{namespace}}",
+    "shortDescription": "{{shortDescription}}"
+  }

--- a/assessments/IB/templates/assessments.jsont
+++ b/assessments/IB/templates/assessments.jsont
@@ -5,7 +5,7 @@
     "namespace": "{{namespace}}",
     "academicSubjects": [
         {
-            "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#{{edfi_subject}}"
+            "academicSubjectDescriptor": "{{edfi_subject}}"
         }
     ],
     "scores": [

--- a/assessments/IB/templates/assessments.jsont
+++ b/assessments/IB/templates/assessments.jsont
@@ -1,0 +1,58 @@
+{
+    "assessmentIdentifier": "{{assessment_identifier}}",
+    "assessmentTitle": "{{assessment_title}}",
+    "assessmentFamily": "{{assessment_family}}",
+    "namespace": "{{namespace}}",
+    "academicSubjects": [
+        {
+            "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#{{edfi_subject}}"
+        }
+    ],
+    "scores": [
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Category",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Group",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Level",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Predicted Grade",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Grade",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#EE/TOK Bonus Points",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Total Points",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      }
+    ],
+    "performanceLevels": [
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Diploma Result Code",
+        "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#D",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Diploma Result Code",
+        "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#F",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      },
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Diploma Result Code",
+        "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#P",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      }
+    ]
+  }

--- a/assessments/IB/templates/performanceLevelDescriptors.jsont
+++ b/assessments/IB/templates/performanceLevelDescriptors.jsont
@@ -1,0 +1,6 @@
+{
+    "codeValue": "{{codeValue}}",
+    "description": "{{description}}",
+    "namespace": "{{namespace}}",
+    "shortDescription": "{{shortDescription}}"
+  }

--- a/assessments/IB/templates/studentAssessments.jsont
+++ b/assessments/IB/templates/studentAssessments.jsont
@@ -31,12 +31,14 @@
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Predicted Grade",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{predicted_grade}}"
-    },
+    }
+  {% subject_grade is not none and subject_grade | length %},
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Grade",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{subject_grade}}"
     }
+  {% endif %}
   {% if category == 'DIPLOMA' %},
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#EE/TOK Bonus Points",

--- a/assessments/IB/templates/studentAssessments.jsont
+++ b/assessments/IB/templates/studentAssessments.jsont
@@ -32,7 +32,7 @@
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{predicted_grade}}"
     }
-  {% subject_grade is not none and subject_grade | length %},
+  {% if subject_grade is not none and subject_grade | length %},
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Grade",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",

--- a/assessments/IB/templates/studentAssessments.jsont
+++ b/assessments/IB/templates/studentAssessments.jsont
@@ -1,0 +1,61 @@
+{
+  "studentAssessmentIdentifier": "{{student_assessment_identifier}}",
+  "assessmentReference": {
+    "assessmentIdentifier": "{{assessment_identifier}}",
+    "namespace": "{{namespace}}"
+  },
+  "schoolYearTypeReference": {
+    "schoolYear": {{school_year}}
+  },
+  "studentReference": {
+    "studentUniqueId": "{{student_unique_id}}"
+  },
+  "administrationDate": "{{administration_date}}",
+  "scoreResults": [
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Category",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
+      "result": "{{category}}"
+    },
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Group",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
+      "result": "{{group_number}}"
+    },
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Level",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level",
+      "result": "{{level}}"
+    },
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Predicted Grade",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+      "result": "{{predicted_grade}}"
+    },
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Subject Grade",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+      "result": "{{subject_grade}}"
+    }
+  {% if category == 'DIPLOMA' %},
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#EE/TOK Bonus Points",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+      "result": "{{ee_tok_bonus_points}}"
+    },
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Total Points",
+      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+      "result": "{{total_points}}"
+    }
+  ],
+
+  "performanceLevels": [
+    {
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Diploma Result Code",
+      "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#{{result_code}}",
+      "performanceLevelMet": true
+    }
+ {% endif %}
+  ]
+}


### PR DESCRIPTION
## Description & motivation
This bundle maps International Baccalaureate (IB) assessment results. There are a few quirks to be aware of:
- There are no student IDs provided in the file. The bundle expects a `student_unique_id` column, which will need to be added and populated in a pre-processing step.
- The assessment identifier includes the course title. There are many possible courses, so we are getting the list of assessment records that will need to be sent from the data. In order to provide an `AcademicSubjectDescriptor` for the assessment, I mapped the file's `group_number` column to Ed-Fi academic subjects.

## PR Merge Priority:
- Low

## Tests and QC done:
- Successfully ran `lightbeam validate` (the new v0.1.3 version) on Denver's 2023 results 

## Assessment Identifier Decision
Chosen format: Assessment identifier includes the course title, i.e. ‘IB - BIOLOGY’. Diploma related results are included with each course level result.
- Alternate option 1: Single IB assessment with diploma related results at the assessment level and courses as objective assessments. Drawbacks: for students who do not have diploma results (about half), the student assessment record would have no real scores.
- Alternate option 2: Assessment identifier includes the course title, with an additional IB assessment identifier for the diploma level results. Drawbacks: two different grains for the same assessment, difficult to associate diploma results with the relevant course results.
- Alternate option 3: Assessment identifiers which include course title are used for students with no diploma results; an additional IB assessment identifier is used for students with diploma results and courses are added as objective assessments. Drawbacks: two different grains for the same assessment, difficult to compare course level results for the two groups of students with the scores in different parts of the model.
