### PR TITLE
Feature/ACCUPLACER

### DIFF
--- a/assessments/ACCUPLACER/README.md
+++ b/assessments/ACCUPLACER/README.md
@@ -1,0 +1,86 @@
+* **Title**: ACCUPLACER Placement Tests - API 3.X
+* **Description**: This template maps College Board Next-Generation ACCUPLACER files. It currently handles the placement tests only. It may be extended in the future to map ESL and Essay tests.
+* **API version**: 5.2
+* **Submitter name**: Samantha LeBlanc
+* **Submitter organization**: Education Analytics
+
+To run this bundle, please add your own source file(s) and column(s):
+<details>
+<summary><code>data/accuplacer.csv</code></summary>
+This template will only work with the ACCUPLACER placement test results file.
+</details>
+
+<details>
+<summary><code>seeds/student_ids.csv</code></summary>
+
+This is a [crosswalk file](https://en.wikipedia.org/wiki/Schema_crosswalk) for translating the student IDs in the assessment CSVs to student IDs in Ed-Fi (one may be a state ID and the other a district ID, for example). 
+
+This file is **optional**. If one of the student ID column within the assessment file maps to Ed-Fi's `studentUniqueId`, you can omit the crosswalk file.
+
+If you need to use a crosswalk, see the CLI parameters section below.
+
+Required columns:
+   - `student_id_from`
+   - `student_id_to`
+</details>
+
+## CLI Parameters
+
+### Required
+- OUTPUT_DIR: Where output files will be written
+- STATE_FILE: Where to store the earthmover runs.csv file
+- BUNDLE_DIR: Parent folder of the bundle, where `earthmover.yaml` lives
+- INPUT_FILE: The student assessment file to be mapped
+- API_YEAR: The API year of the ODS for which we would send these records
+
+### Optional
+If student IDs must be mapped, provide the following additional parameters:
+- STUDENT_ID_XWALK: Path to a two-column CSV mapping `student_id_from`, an ID included in the assessment file, and `student_id_to`, the `studentUniqueId` value in Ed-Fi
+
+To query a student ID xwalk from a database, provide the following additional parameters:
+- DATABASE_CONNECTION: [SQLAlchemy database URL](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls)
+- STUDENT_ID_QUERY: Crosswalk query with columns `student_id_from` and `student_id_to`. You may need to use `$$` in the place of single quotes to avoid issues with constructing the query string.
+
+### Examples
+Using an ID column from the assessment file:
+```bash
+earthmover run -c ./earthmover.yaml -p '{
+"BUNDLE_DIR": ".",
+"STATE_FILE": "./state",
+"INPUT_FILE": "path/to/BESS.csv",
+"OUTPUT_DIR": "./output",
+"API_YEAR": "2023" }'
+```
+
+Using a student ID crosswalk
+```bash
+earthmover run -c ./earthmover.yaml -p '{
+"BUNDLE_DIR": ".",
+"STATE_FILE": "./state",
+"INPUT_FILE": "path/to/BESS.csv",
+"OUTPUT_DIR": "./output",
+"API_YEAR": "2023"
+"STUDENT_ID_XWALK": "path/to/student_id_xwalk.csv" }'
+```
+
+Using a database connection:
+```bash
+earthmover run -c ./earthmover.yml -p '{
+"BUNDLE_DIR": ".",
+"STATE_FILE": "./state",
+"INPUT_FILE": "path/to/BESS.csv",
+"OUTPUT_DIR": "./output",
+"API_YEAR": "2023"
+"DATABASE_CONNECTION": "database_connection_string"
+"STUDENT_ID_QUERY": "select id_1 as student_id_from, id_2 as student_id_to from student_table" }'
+```
+
+Once you have inspected the output JSONL for issues, check the settings in `lightbeam.yaml` and transmit them to your Ed-Fi API with
+```bash
+lightbeam validate+send -c ./lightbeam.yaml -p '{
+"DATA_DIR": "./output/",
+"EDFI_API_BASE_URL": "yourURL",
+"EDFI_API_CLIENT_ID": "yourID",
+"EDFI_API_CLIENT_SECRET": "yourSecret",
+"API_YEAR": "yourAPIYear" }'
+```

--- a/assessments/ACCUPLACER/earthmover.yaml
+++ b/assessments/ACCUPLACER/earthmover.yaml
@@ -2,7 +2,7 @@ version: 2
 
 
 config:
-  log_level: DEBUG
+  log_level: INFO
   output_dir: ${OUTPUT_DIR}
   memory_limit: 1GB
   state_file: ${STATE_FILE}

--- a/assessments/ACCUPLACER/earthmover.yaml
+++ b/assessments/ACCUPLACER/earthmover.yaml
@@ -1,0 +1,127 @@
+version: 2
+
+
+config:
+  log_level: DEBUG
+  output_dir: ${OUTPUT_DIR}
+  memory_limit: 1GB
+  state_file: ${STATE_FILE}
+  show_graph: False
+  show_stacktrace: true
+  parameter_defaults:
+    STUDENT_ID_NAME: 'Student ID'
+    STUDENT_ID_XWALK: ''
+    STUDENT_ID_QUERY: ''
+    DATABASE_CONNECTION: ''
+
+
+sources:
+  accuplacer_input:
+    file: ${INPUT_FILE}
+    header_rows: 1
+  assessments:
+    file: ${BUNDLE_DIR}/seeds/assessments.csv
+    header_rows: 1
+  assessmentReportingMethodDescriptors:
+    file: ${BUNDLE_DIR}/seeds/assessmentReportingMethodDescriptors.csv
+    header_rows: 1
+  {% if "${STUDENT_ID_QUERY}" | length %}
+  student_id_mapping:
+    connection: ${DATABASE_CONNECTION}
+    query: ${STUDENT_ID_QUERY}
+
+  {% else %}
+  student_id_mapping:
+    file: ${STUDENT_ID_XWALK}
+    header_rows: 1
+    columns: 
+      - student_id_from 
+      - student_id_to
+    optional: True 
+  {% endif %}
+
+
+transformations:
+  accuplacer_snake_case:
+    source: $sources.accuplacer_input
+    operations:
+      - operation: join 
+        sources: 
+          - $sources.student_id_mapping
+        left_key: Student ID
+        right_key: student_id_from
+        join_type: left  
+      - operation: duplicate_columns
+        columns: 
+          ${STUDENT_ID_NAME}: student_unique_id
+      - operation: snake_case_columns
+
+  {% set assessments = ['reading', 'writing', 'arithmetic', 'quantitative_reasoning_algebra_and_statistics', 'advanced_algebra_and_functions'] %}
+  {% for assessment in assessments %}
+  scores_{{assessment}}:
+    source: $transformations.accuplacer_snake_case
+    operations:
+      - operation: keep_columns
+        columns:
+          - student_unique_id
+          - test_end
+          - next_generation_{{assessment}}
+      - operation: add_columns
+        columns:
+          assessment_identifier: {{assessment}}
+      - operation: rename_columns
+        columns:
+          next_generation_{{assessment}}: scale_score
+      - operation: filter_rows
+        query: scale_score != ''
+        behavior: include
+  {% endfor %}  
+
+  stacked_assessments:
+    source: $transformations.scores_{{assessments[0]}}
+    operations:
+      - operation: union
+        sources:
+          {% for assessment in assessments[1:] %}
+          - $transformations.scores_{{assessment}}
+          {% endfor %}
+
+  accuplacer_results:
+    source: $transformations.stacked_assessments
+    operations:
+      - operation: map_values
+        column: assessment_identifier
+        mapping:
+          reading: accuplacer_reading
+          writing: accuplacer_writing
+          arithmetic: accuplacer_arithmetic
+          quantitative_reasoning_algebra_and_statistics: accuplacer_quant_algebra_stats
+          advanced_algebra_and_functions: accuplacer_adv_algebra_functions
+      - operation: add_columns
+        columns:
+          namespace: "uri://accuplacer.collegeboard.org"
+          school_year: ${API_YEAR}
+          combined_student_assessment_id: "{%raw%}{{student_unique_id}}-{{test_end}}-{{assessment_identifier}}{%endraw%}" 
+          student_assessment_identifier: "{%raw%}{{ md5(combined_student_assessment_id) }}{%endraw%}" 
+      - operation: date_format
+        column: test_end
+        from_format: "%m/%d/%Y"
+        to_format: "%Y-%m-%d"
+
+
+destinations:
+  assessments:
+    source: $sources.assessments
+    template: ${BUNDLE_DIR}/templates/assessments.jsont
+    extension: jsonl
+    linearize: True
+  assessmentReportingMethodDescriptors:
+    source: $sources.assessmentReportingMethodDescriptors
+    template: ${BUNDLE_DIR}/templates/assessmentReportingMethodDescriptors.jsont
+    extension: jsonl
+    linearize: True
+  studentAssessments:
+    source: $transformations.accuplacer_results
+    template: ${BUNDLE_DIR}/templates/studentAssessments.jsont
+    extension: jsonl
+    linearize: True

--- a/assessments/ACCUPLACER/lightbeam.yaml
+++ b/assessments/ACCUPLACER/lightbeam.yaml
@@ -1,0 +1,18 @@
+state_dir: ${STATE_DIR}
+data_dir: ${DATA_DIR}
+edfi_api:
+  base_url: ${EDFI_API_BASE_URL}
+  version: 3
+  mode: district_specific
+  year: ${API_YEAR}
+  client_id: ${EDFI_API_CLIENT_ID}
+  client_secret: ${EDFI_API_CLIENT_SECRET}
+connection:
+  pool_size: 2
+  timeout: 6000
+  num_retries: 10
+  backoff_factor: 1.5
+  retry_statuses: [429, 500, 502, 503, 504]
+  verify_ssl: True
+log_level: DEBUG
+show_stacktrace: True

--- a/assessments/ACCUPLACER/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/ACCUPLACER/seeds/assessmentReportingMethodDescriptors.csv
@@ -1,2 +1,2 @@
 codeValue,description,namespace,shortDescription
-Scale Score,Scores are transformations of the scores directly resulting from the CAT algorithm. Scaled scores for placement tests range from 200 to 300 while scaled scores for ESL tests range from 20 to 120.,uri://accuplacer.collegeboard.org/AssessmentReportingMethodDescriptor,Scaled score from 200 to 300 for placement tests or 20 to 120 for ESL tests.
+Scale Score,Scores are transformations of the scores directly resulting from the CAT algorithm. Scaled scores for placement tests range from 200 to 300 while scaled scores for ESL tests range from 20 to 120.,uri://accuplacer.collegeboard.org/AssessmentReportingMethodDescriptor,Scale Score

--- a/assessments/ACCUPLACER/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/ACCUPLACER/seeds/assessmentReportingMethodDescriptors.csv
@@ -1,0 +1,2 @@
+codeValue,description,namespace,shortDescription
+Scale Score,Scores are transformations of the scores directly resulting from the CAT algorithm. Scaled scores for placement tests range from 200 to 300 while scaled scores for ESL tests range from 20 to 120.,uri://accuplacer.collegeboard.org/AssessmentReportingMethodDescriptor,Scaled score from 200 to 300 for placement tests or 20 to 120 for ESL tests.

--- a/assessments/ACCUPLACER/seeds/assessments.csv
+++ b/assessments/ACCUPLACER/seeds/assessments.csv
@@ -1,0 +1,6 @@
+assessment_identifier,namespace,assessment_title,assessment_family,academic_subject_descriptor
+accuplacer_reading,uri://accuplacer.collegeboard.org,"ACCUPLACER Reading",ACCUPLACER,uri://ed-fi.org/AcademicSubjectDescriptor#Reading
+accuplacer_writing,uri://accuplacer.collegeboard.org,"ACCUPLACER Writing",ACCUPLACER,uri://ed-fi.org/AcademicSubjectDescriptor#Writing
+accuplacer_arithmetic,uri://accuplacer.collegeboard.org,"ACCUPLACER Arithmetic",ACCUPLACER,uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics
+accuplacer_quant_algebra_stats,uri://accuplacer.collegeboard.org,"ACCUPLACER Quantitative Reasoning, Algebra, and Statistics",ACCUPLACER,uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics
+accuplacer_adv_algebra_functions,uri://accuplacer.collegeboard.org,"ACCUPLACER Advanced Algebra and Functions",ACCUPLACER,uri://ed-fi.org/AcademicSubjectDescriptor#Mathematics

--- a/assessments/ACCUPLACER/templates/assessmentReportingMethodDescriptors.jsont
+++ b/assessments/ACCUPLACER/templates/assessmentReportingMethodDescriptors.jsont
@@ -1,0 +1,6 @@
+{
+    "codeValue": "{{codeValue}}",
+    "description": "{{description}}",
+    "namespace": "{{namespace}}",
+    "shortDescription": "{{shortDescription}}"
+  }

--- a/assessments/ACCUPLACER/templates/assessments.jsont
+++ b/assessments/ACCUPLACER/templates/assessments.jsont
@@ -1,0 +1,17 @@
+{
+    "assessmentIdentifier": "{{assessment_identifier}}",
+    "assessmentTitle": "{{assessment_title}}",
+    "assessmentFamily": "{{assessment_family}}",
+    "namespace": "{{namespace}}",
+    "academicSubjects": [
+        {
+        "academicSubjectDescriptor": "{{academic_subject_descriptor}}"
+        }
+    ],
+    "scores": [
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale Score",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      }
+    ]
+  }

--- a/assessments/ACCUPLACER/templates/studentAssessments.jsont
+++ b/assessments/ACCUPLACER/templates/studentAssessments.jsont
@@ -1,0 +1,21 @@
+{
+    "studentAssessmentIdentifier": "{{student_assessment_identifier}}",
+    "assessmentReference": {
+      "assessmentIdentifier": "{{assessment_identifier}}",
+      "namespace": "{{namespace}}"
+    },
+    "schoolYearTypeReference": {
+      "schoolYear": {{school_year}}
+    },
+    "studentReference": {
+      "studentUniqueId": "{{student_unique_id}}"
+    },
+    "administrationDate": "{{test_end}}",
+    "scoreResults": [
+      {
+        "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale Score",
+        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+        "result": "{{scale_score}}"
+      }
+    ]
+  }


### PR DESCRIPTION
## Description & motivation
This bundle maps ACCUPLACER placement test results. There are other types of ACCUPLACER tests (ESL and Essay) but the placement tests are the only ones we have encountered so far.

Jay fixed an earthmover bug that I found with this file, so it will work with earthmover v0.3.4+ but not 0.3.2 or 0.3.3.

## PR Merge Priority:
- Low

## Tests and QC done:
- Successfully ran `lightbeam validate` (the new v0.1.3 version) on Denver's 2023 results 

## Assessment Identifier Decision
The assessment identifier includes the name/subject of the placement test, i.e. 'ACCUPLACER - Reading'. There is a single score at this level and no overall scores.