### PR TITLE
Bugfix/Istation - allow scores to be null

### DIFF
--- a/assessments/iStation/earthmover.yml
+++ b/assessments/iStation/earthmover.yml
@@ -72,7 +72,7 @@ transformations:
           July_perf_lvl: "{%raw%}{% if July_LEVEL is defined %}{{July_LEVEL}}{% else %}{{July_TIER}}{% endif %}{%endraw%}"
           perf_lvl_type: "{%raw%}{% if August_LEVEL is defined %}level{% else %}tier{% endif %}{%endraw%}"
 
-  {% set months = ['August', 'September', 'October', 'November', 'December', 'January', 'February', 'March', 'April', 'May'] %}
+  {% set months = ['August', 'September', 'October', 'November', 'December', 'January', 'February', 'March', 'April', 'May', 'June'] %}
   {% for month in months %}
   scores_{{month}}:
     source: $$transformations.define_perf_levels

--- a/assessments/iStation/templates/studentAssessments.jsont
+++ b/assessments/iStation/templates/studentAssessments.jsont
@@ -18,14 +18,16 @@
       "assessmentReportingMethodDescriptor": "uri://istation.com/AssessmentReportingMethodDescriptor#Score",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{score}}"
-    },
+    }
+    {% if percentile is not none and percentile | length %},
     {
       "assessmentReportingMethodDescriptor": "uri://istation.com/AssessmentReportingMethodDescriptor#Percentile",
       "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
       "result": "{{percentile}}"
     }
-  ],
-
+    {% endif %}
+  ]
+  {% if perf_lvl_value is not none and perf_lvl_value | length %},
   "performanceLevels": [
     {% if perf_lvl_type == 'level' %}
       {
@@ -41,4 +43,5 @@
       }
     {% endif %}
     ]
+  {% endif %}
 }


### PR DESCRIPTION
## Description & motivation
This PR fixes a small issue in the Istation bundle: in rare cases, students can have score but a null percentile and/or performance level. These scores should still be able to be sent.

## Tests and QC done:
Verified with GSN results - all sent successfully

## PR Merge Priority:
- High - needed for Denver's next Istation run