### PR TITLE
Add suport for data from the Istaion api data export endpoint 

### DIFF
--- a/assessments/iStation/earthmover.yml
+++ b/assessments/iStation/earthmover.yml
@@ -110,13 +110,35 @@ transformations:
           - $transformations.scores_{{month}}
           {% endfor %}
 
+  # The export data is already stacked
+  renamed_export:
+    source: $sources.istation_input
+    operations:
+      - operation: add_columns
+        columns:
+          perf_lvl_type: "{%raw%}tier{%endraw%}"
+      - operation: rename_columns
+        columns:
+          STUDENT_ID: student_id
+          DOMAIN: domain
+          GRADE: grade_level
+          UDATE: admin_date
+          SCORE: score
+          PTILE: percentile
+          TIER: perf_lvl_value
+
   {% if "${SUBJECT}" == "reading" %}
     {% set test = "Istation Reading" %}
   {% elif "${SUBJECT}" == "spanish" %}
     {% set test = "Istation Spanish" %}
   {% endif %}
   studentAssessments:
-    source: $transformations.stacked_months
+    source: 
+      {% if "${ISTATION_ENDPOINT}" == "export" %}
+      $transformations.renamed_export
+      {% else %}
+      $transformations.stacked_months
+      {% endif %}
     operations:
       - operation: join
         sources:


### PR DESCRIPTION
# Istation Data Export End Point

The Istation API has two endpoints for data. The reports endpoint can be queried once a month for new data and will give post process data that matches the limits of Istations own analytics. The Export Endpoint, also known as the Alternative Endpoint, provides all data for a school year up to the time of request. Only this endpoint provides overall and all subtest scores for a year and for all assessments. DPS needs to use this endpoint, and we hope that it may be helpful to other schools to have access to this end point also.

[You can find more documentation on this endpoint on the iStation website. ](https://help.istation.com/en_US/how-do-i-automate-data-exports)

The url for this endpoint is `https://secure.istation.com/Export/AssessmentResult?Year=YYYY` where `YYYY` is the starting year of the school year of interest.

## What changed

- **New transformation: ** A new transformation has been added, `rename_export` that renames the input dataset to match the names of the stacked dataset that would otherwise be created from the monthly reports data.
- **New Argument:** If the input data is from the export endpoint, the user must provide a newly added arguments `ISTATION_ENDPOINT="export"`. This feeds into the condition to select the correct source transformation. If the value is missing or any value other than 'export', the normal transformations will run.

## Concerns

 - **Many Warnings** Because the conditional Jinja only encompasses a source statement, many warnings are generated for the transformations that are not used. This seems like a fine sacrifices for readability, and the needed data.

## Tests

[ ] Light beam validation. I am working on being able to validate my example data with my ODS. I am waiting on credentials
[X] I am able to handle data from both data sources and get the same resulting json, although the export json has more data obviously.
