### PR TITLE
adding `limit_rows`, `require_rows`, and header Jinja template for `input_no_student_id_match`

### DIFF
--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -283,10 +283,12 @@ transformations:
       - operation: add_columns
         columns:
           __join_id: "1"
+      # ensure there's not more than 1 row:
       - operation: limit_rows
         count: 1
     expect:
       - __match_rate | float >= ${REQUIRED_ID_MATCH_RATE}
+    # ensure there's not 0 rows:
     require_rows: True
 
   edfi_roster:
@@ -395,6 +397,7 @@ destinations:
     # here we are assuming that INPUT_FILE is a CSV, but that might not be true... maybe
     # need to switch destination template and extension based on INPUT_FILE type?
     template: ./verbatim.csvt
+    # add a CSV header with the columns:
     header: |
       {%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}
 

--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -283,8 +283,11 @@ transformations:
       - operation: add_columns
         columns:
           __join_id: "1"
+      - operation: limit_rows
+        count: 1
     expect:
-    - __match_rate | float >= ${REQUIRED_ID_MATCH_RATE}
+      - __match_rate | float >= ${REQUIRED_ID_MATCH_RATE}
+    require_rows: True
 
   edfi_roster:
     source: $transformations.unpacked_edfi_roster
@@ -392,6 +395,9 @@ destinations:
     # here we are assuming that INPUT_FILE is a CSV, but that might not be true... maybe
     # need to switch destination template and extension based on INPUT_FILE type?
     template: ./verbatim.csvt
+    header: |
+      {%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}
+
     extension: csv
     linearize: True
 


### PR DESCRIPTION
This PR adds:
* `limit_rows` to the `best_id_match` node, to ensure only one pair of IDs is used even if more than one exceeds the `REQUIRED_ID_MATCH_RATE`
* `require_rows` to the `best_id_match` node, to ensure that at lease one pair of IDs exceeds the `REQUIRED_ID_MATCH_RATE`
* a header Jinja template for `input_no_student_id_match`, so the output file is a valid CSV with the original header

(These use new earthmover features available in the just-released [v0.3.7](https://github.com/edanalytics/earthmover/releases/tag/v0.3.7).)