### PR TITLE
IB bundle: add compatibility with the student ID package

### DIFF
--- a/assessments/IB/README.md
+++ b/assessments/IB/README.md
@@ -21,6 +21,7 @@ The IB results file does not include student IDs besides internal IB candidate I
 - STATE_FILE: Where to store the earthmover runs.csv file
 - INPUT_FILE: The path to the IB .csv file you want to transform
 - API_YEAR: The API year that the output of this template will be sent to
+- STUDENT_ID_NAME: Which column to use as the Ed-Fi studentUniqueId. Default column is `student_unique_id`, which must be added to the file
 
 ### Examples
 Running earthmover for an IB file:
@@ -29,7 +30,8 @@ earthmover run -c ./earthmover.yaml -p '{
 "OUTPUT_DIR": "./output",
 "STATE_FILE": "./runs.csv",
 "INPUT_FILE": "./data/sample_anonymized_file.csv",
-"API_YEAR": "2024" }'
+"API_YEAR": "2024",
+"STUDENT_ID_NAME": "student_unique_id" }'
 ```
 
 Once you have inspected the output JSONL for issues, check the settings in `lightbeam.yaml` and transmit them to your Ed-Fi API with

--- a/assessments/IB/earthmover.yaml
+++ b/assessments/IB/earthmover.yaml
@@ -7,6 +7,9 @@ config:
   state_file: ${STATE_FILE}
   show_graph: False
   show_stacktrace: true
+  parameter_defaults:
+    STUDENT_ID_NAME: 'edFi_studentUniqueID' # default to the column added by the apply_xwalk package of student ID xwalking feature
+    POSSIBLE_STUDENT_ID_COLUMNS: 'student_unique_id' # this column will need to be added and populated as a pre-preprocessing step before this bundle can be used
   macros: > 
       {% macro group_number_with_language(value) -%}
       {%- if group_number == '1' -%}
@@ -34,8 +37,12 @@ sources:
 
 
 transformations:
-  ib_student_results:
+  input:
     source: $sources.input
+    operations: []
+    
+  ib_student_results:
+    source: $transformations.input
     operations:
       - operation: snake_case_columns
       - operation: combine_columns
@@ -56,6 +63,9 @@ transformations:
           school_year: ${API_YEAR}
           administration_date: "{%raw%}{{year}}-{%- if month == 'MAY' -%}05{%- else -%}11{%- endif -%}-01{%endraw%}"
           student_assessment_identifier: "{%raw%}{{ md5(combined_student_assessment_id) }}{%endraw%}" 
+      - operation: rename_columns
+        columns: 
+          ${STUDENT_ID_NAME}: student_id
   
   student_assessments:
     source: $transformations.ib_student_results

--- a/assessments/IB/templates/studentAssessments.jsont
+++ b/assessments/IB/templates/studentAssessments.jsont
@@ -8,7 +8,7 @@
     "schoolYear": {{school_year}}
   },
   "studentReference": {
-    "studentUniqueId": "{{student_unique_id}}"
+    "studentUniqueId": "{{student_id}}"
   },
   "administrationDate": "{{administration_date}}",
   "scoreResults": [


### PR DESCRIPTION
The IB bundle did not have the necessary transformations for use with the student ID package because the file itself does not have student IDs. Added compatibility so that the user-provided ID column will be checked against Ed-Fi to produce the non-matching students file.