### PR TITLE
Bugfix/escape commas when writing to CSV

### DIFF
--- a/packages/student_ids/verbatim.csvt
+++ b/packages/student_ids/verbatim.csvt
@@ -1,3 +1,3 @@
 {% for key, value in __row_data__.pop('__row_data__').items() -%}
-{{value|trim}}{% if not loop.last %},{% endif %}
+"{{value|trim}}"{% if not loop.last %},{% endif %}
 {%- endfor %}


### PR DESCRIPTION
Adds quotes to fix an issue with writing out a non-matched students file when there are commas in the data