### PR TITLE
add template for stuAssessEdOrgAssoc

### DIFF
--- a/assessments/_template_bundle/data/sample_anonymized_file.csv
+++ b/assessments/_template_bundle/data/sample_anonymized_file.csv
@@ -1,6 +1,6 @@
-studentId,schoolYear,studentName,adminDate,grade,scaleScore,sem,performanceLevel,goalMet,math123Percentage,math123Level,math2Percentage,math2Level,subMath1Percentage,subMath1Level
-fake_student_1,2024,Fake Student 1,01/01/2024,K,100,10,Did not yet meet expectations,No,20.10,Lower than Average,20.20,Lower than Average,20.20,Lower than Average
-fake_student_2,2024,Fake Student 2,01/02/2024,1,200,20,Did not yet meet expectations,No,40.40,Lower than Average,40.40,Lower than Average,40.40,Lower than Average
-fake_student_3,2024,Fake Student 3,01/03/2024,2,300,30,Met expectations,Yes,60.60,Average,60.60,Average,60.60,Average
-fake_student_4,2024,Fake Student 4,01/04/2024,3,400,40,Met expectations,Yes,80.80,Higher than Average,80.80,Lower than Average,80.00,Lower than Average
-100,2024,Fake Student 5,01/05/2024,3,500,50,Met expectations,Yes,100.00,Higher than Average,100.00,Lower than Average,100.00,Lower than Average
+studentId,schoolYear,studentName,schoolID,adminDate,grade,scaleScore,sem,performanceLevel,goalMet,math123Percentage,math123Level,math2Percentage,math2Level,subMath1Percentage,subMath1Level
+fake_student_1,2024,Fake Student 1,123,01/01/2024,K,100,10,Did not yet meet expectations,No,20.10,Lower than Average,20.20,Lower than Average,20.20,Lower than Average
+fake_student_2,2024,Fake Student 2,123,01/02/2024,1,200,20,Did not yet meet expectations,No,40.40,Lower than Average,40.40,Lower than Average,40.40,Lower than Average
+fake_student_3,2024,Fake Student 3,456,01/03/2024,2,300,30,Met expectations,Yes,60.60,Average,60.60,Average,60.60,Average
+fake_student_4,2024,Fake Student 4,456,01/04/2024,3,400,40,Met expectations,Yes,80.80,Higher than Average,80.80,Lower than Average,80.00,Lower than Average
+100,2024,Fake Student 5,456,01/05/2024,3,500,50,Met expectations,Yes,100.00,Higher than Average,100.00,Lower than Average,100.00,Lower than Average

--- a/assessments/_template_bundle/data/sample_anonymized_file.csv
+++ b/assessments/_template_bundle/data/sample_anonymized_file.csv
@@ -1,4 +1,4 @@
-studentId,schoolYear,studentName,schoolID,adminDate,grade,scaleScore,sem,performanceLevel,goalMet,math123Percentage,math123Level,math2Percentage,math2Level,subMath1Percentage,subMath1Level
+studentId,schoolYear,studentName,adminSchoolID,adminDate,grade,scaleScore,sem,performanceLevel,goalMet,math123Percentage,math123Level,math2Percentage,math2Level,subMath1Percentage,subMath1Level
 fake_student_1,2024,Fake Student 1,123,01/01/2024,K,100,10,Did not yet meet expectations,No,20.10,Lower than Average,20.20,Lower than Average,20.20,Lower than Average
 fake_student_2,2024,Fake Student 2,123,01/02/2024,1,200,20,Did not yet meet expectations,No,40.40,Lower than Average,40.40,Lower than Average,40.40,Lower than Average
 fake_student_3,2024,Fake Student 3,456,01/03/2024,2,300,30,Met expectations,Yes,60.60,Average,60.60,Average,60.60,Average

--- a/assessments/_template_bundle/earthmover.yaml
+++ b/assessments/_template_bundle/earthmover.yaml
@@ -49,6 +49,7 @@ transformations:
       - operation: duplicate_columns
         columns: 
           ${STUDENT_ID_NAME}: studentUniqueId
+          schoolID: educationOrganizationId
       - operation: add_columns
         columns:
           assessmentIdentifier: "fake_math_assessment"
@@ -131,4 +132,8 @@ destinations:
   studentAssessments:
     source: $transformations.clean_results
     template: ./templates/studentAssessments.jsont
+    extension: jsonl
+  studentAssessmentEducationOrganizationAssociations:
+    source: $transformations.clean_results
+    template: ./templates/studentAssessmentEducationOrganizationAssociations.jsont
     extension: jsonl

--- a/assessments/_template_bundle/earthmover.yaml
+++ b/assessments/_template_bundle/earthmover.yaml
@@ -49,11 +49,12 @@ transformations:
       - operation: duplicate_columns
         columns: 
           ${STUDENT_ID_NAME}: studentUniqueId
-          schoolID: educationOrganizationId
+          adminSchoolID: educationOrganizationId
       - operation: add_columns
         columns:
           assessmentIdentifier: "fake_math_assessment"
           namespace: "uri://fakeassessment.com"
+          educationOrganizationAssociationTypeDescriptor: "uri://ed-fi.org/EducationOrganizationAssociationTypeDescriptor/Administration"
       - operation: combine_columns
         columns:
           - studentId

--- a/assessments/_template_bundle/templates/studentAssessmentEducationOrganizationAssociations.jsont
+++ b/assessments/_template_bundle/templates/studentAssessmentEducationOrganizationAssociations.jsont
@@ -1,0 +1,15 @@
+ {
+  "educationOrganizationAssociationTypeDescriptor": "{{educationOrganizationAssociationTypeDescriptor}}",
+  "educationOrganizationReference": {
+    "educationOrganizationId": {{educationOrganizationId}}
+  },
+  "schoolYearTypeReference": {
+    "schoolYear": "{{schoolYear}}"
+  },
+  "studentAssessmentReference": {
+    "assessmentIdentifier": "{{assessmentIdentifier}}",
+    "namespace": "{{namespace}}",
+    "studentAssessmentIdentifier": "{{studentAssessmentIdentifier}}",
+    "studentUniqueId": "{{studentUniqueId}}",
+  }
+}


### PR DESCRIPTION
edits template bundle to include example creation of studentAssessmentEducationOrganizationAssociations endpoint.

I chose to just show the simple case where there's one edOrg, of type Administration. But maybe it should show how to handle when there are multiple types (would need an extra transformation for that)

Note, I haven't tested this yet

Do we need a way to xwalk ed org IDs?