### PR TITLE
Add parameter defaults to student_ids and student_id_wrapper

### DIFF
--- a/packages/student_id_wrapper/earthmover.yaml
+++ b/packages/student_id_wrapper/earthmover.yaml
@@ -6,6 +6,7 @@ config:
   show_stacktrace: True
   show_graph: False
   parameter_defaults:
+    OUTPUT_DIR: outputs
     ASSESSMENT_BUNDLE_BRANCH: main
     EDFI_STUDENT_ID_TYPES: Local,School,District,State
 

--- a/packages/student_id_wrapper/earthmover.yaml
+++ b/packages/student_id_wrapper/earthmover.yaml
@@ -6,7 +6,7 @@ config:
   show_stacktrace: True
   show_graph: False
   parameter_defaults:
-    OUTPUT_DIR: outputs
+    OUTPUT_DIR: output
     ASSESSMENT_BUNDLE_BRANCH: main
     EDFI_STUDENT_ID_TYPES: Local,School,District,State
 

--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -3,6 +3,7 @@ version: 2
 config:
   tmp_dir: ${TEMPORARY_DIRECTORY}
   parameter_defaults:
+    TEMPORARY_DIRECTORY: /tmp
     # The following values are required to use this bundle:
     
     # a comma-separated list of studentEdOrgAssns.studentIdentificationCodes.studentIdentificationSystem


### PR DESCRIPTION
Take advantage of this new [Earthmover feature](https://github.com/edanalytics/earthmover/pull/130) to make these two packages a bit easier to work with