### PR TITLE
Feature/iready  descriptor namespace

### DIFF
--- a/assessments/i-Ready/earthmover.yaml
+++ b/assessments/i-Ready/earthmover.yaml
@@ -8,6 +8,7 @@ config:
   show_graph: False
   parameter_defaults:
     INPUT_FILETYPE: csv
+    DESCRIPTOR_NAMESPACE: uri://ed-fi.org
     STUDENT_ID_NAME: Student ID
     POSSIBLE_STUDENT_ID_COLUMNS: Student ID
 

--- a/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
@@ -12,7 +12,6 @@ Comprehension: Overall Scale Score,Comprehension: Overall Scale Score,uri://curr
 Comprehension: Literature Scale Score,Comprehension: Literature Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Comprehension: Literature Scale Score
 Comprehension: Informational Text Scale Score,Comprehension: Informational Text Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Comprehension: Informational Text Scale Score
 Mid On Grade Level Scale Score,Mid On Grade Level Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Mid On Grade Level Scale Score
-Overall Scale Score,Overall Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Overall Scale Score
 Number and Operations Scale Score,Number and Operations Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Number and Operations Scale Score
 Algebra and Algebraic Thinking Scale Score,Algebra and Algebraic Thinking Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Algebra and Algebraic Thinking Scale Score
 Measurement and Data Scale Score,Measurement and Data Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Measurement and Data Scale Score

--- a/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
@@ -27,4 +27,4 @@ Percent Progress to Annual Stretch Growth (%),Percent Progress to Annual Stretch
 Percentile,Percentile,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Percentile
 Grouping,Grouping,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Grouping
 Diagnostic Gain,Diagnostic Gain,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Diagnostic Gain
-Scale score,Scale score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Scale score
+Scale Score,Scale Score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Scale Score

--- a/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
+++ b/assessments/i-Ready/seeds/assessmentReportingMethodDescriptors.csv
@@ -28,4 +28,3 @@ Percentile,Percentile,uri://curriculumassociates.com/AssessmentReportingMethodDe
 Grouping,Grouping,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Grouping
 Diagnostic Gain,Diagnostic Gain,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Diagnostic Gain
 Scale score,Scale score,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,Scale score
-AssessmentGradeLevel,AssessmentGradeLevel,uri://curriculumassociates.com/AssessmentReportingMethodDescriptor,AssessmentGradeLevel

--- a/assessments/i-Ready/templates/assessments.jsont
+++ b/assessments/i-Ready/templates/assessments.jsont
@@ -74,14 +74,14 @@
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Overall Placement",
       "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#{{level}}",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     },
     {%- endfor -%}
     {%- for rel_level in rel_placement_levels -%}
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Overall Relative Placement",
       "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#{{rel_level}}",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     }
     {%- if not loop.last -%},
     {%- else %}{% endif %}{%- endfor -%}
@@ -89,31 +89,31 @@
   "scores": [
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Overall Scale Score",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Integer"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Quantile Measure",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Quantile Range",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Range"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Range"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Lexile Measure",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Lexile Range",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Range"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Range"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Percentile",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Percentile"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Percentile"
     },
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Grouping",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Integer"
     }
   ]
 }

--- a/assessments/i-Ready/templates/objectiveAssessments.jsont
+++ b/assessments/i-Ready/templates/objectiveAssessments.jsont
@@ -87,7 +87,7 @@
   ],
   "scores": [
     {
-      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale score",
+      "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale Score",
       "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Integer"
     }
   ]

--- a/assessments/i-Ready/templates/objectiveAssessments.jsont
+++ b/assessments/i-Ready/templates/objectiveAssessments.jsont
@@ -73,14 +73,14 @@
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Placement",
       "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#{{level}}",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     },
     {%- endfor -%}
     {%- for rel_level in rel_placement_levels -%}
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Relative Placement",
       "performanceLevelDescriptor": "{{namespace}}/PerformanceLevelDescriptor#{{rel_level}}",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Level"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Level"
     }
     {%- if not loop.last -%},
     {%- else %}{% endif %}{%- endfor -%}
@@ -88,7 +88,7 @@
   "scores": [
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale score",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Integer"
     }
   ]
 }

--- a/assessments/i-Ready/templates/studentAssessments.jsont
+++ b/assessments/i-Ready/templates/studentAssessments.jsont
@@ -31,9 +31,7 @@
     {%- endfor -%}
   ],
    "scoreResults": [
-    {%- set all_scores = [
-        [student_grade, "Assessment Grade Level", "Level"]
-    ] -%}
+    {%- set all_scores = [] -%}
 
     {%- if overall_scale_score and overall_scale_score != "NA" -%}
         {%- set _ = all_scores.append([overall_scale_score, "Overall Scale Score", "Integer"]) -%}
@@ -174,4 +172,8 @@
 
     {%- endfor -%}
   ]
+
+  {% if student_grade and student_grade != "NA" %}
+  , "whenAssessedGradeLevel": {{ student_grade }}
+  {% endif %}
 }

--- a/assessments/i-Ready/templates/studentAssessments.jsont
+++ b/assessments/i-Ready/templates/studentAssessments.jsont
@@ -90,7 +90,7 @@
     {%- for score in all_scores -%}
     {
       "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#{{score[1]}}",
-      "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#{{score[2]}}",
+      "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#{{score[2]}}",
       "result": {% if score[2] == 'Integer' -%}"{{score[0] | int}}"{%- else -%}"{{score[0]}}"{%- endif %}
     } {%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}
@@ -166,7 +166,7 @@
       "scoreResults": [
         {
           "assessmentReportingMethodDescriptor": "{{namespace}}/AssessmentReportingMethodDescriptor#Scale Score",
-          "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer",
+          "resultDatatypeTypeDescriptor": "${DESCRIPTOR_NAMESPACE}/ResultDatatypeTypeDescriptor#Integer",
           "result": "{{ obj_assess[0] | int}}"
         }
       ]


### PR DESCRIPTION
This PR makes the following updates to the iReady feature branch:

- Add `DESCRIPTOR_NAMESPACE` environment variable to override Ed-Fi descriptor namespaces around the bundle.
- Move `Assessment Grade Level` into `whenAssessedGradeLevel` instead of a score result.
- Fix casing with `Scale Score` score result.

This has been validated and tested in South Carolina dev.