### PR TITLE
sort `id_match_rates` by `source_column_name` also

### DIFF
--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -229,6 +229,7 @@ transformations:
       - operation: sort_rows
         columns:
           - num_matches
+          - source_column_name
         descending: True
       - operation: add_columns
         columns:


### PR DESCRIPTION
This PR fixes an issue Jay raised where, when multiple source columns produce identical match rates, the sort among them was nondeterministic. This adds `source_column_name` to the [descending] sort, which ensures that not only there is a consistent winner, but also it prefers things like `STATE_STUDENT_ID` to `LOCAL_STUDENT_ID`.