### PR TITLE
ACT: remove nonexistent PL from obj assess

### DIFF
--- a/assessments/ACT/templates/objectiveAssessments.jsont
+++ b/assessments/ACT/templates/objectiveAssessments.jsont
@@ -45,15 +45,5 @@
         "resultDatatypeTypeDescriptor": "{{descriptor_namespace}}/ResultDatatypeTypeDescriptor#Integer"
       }
     ]
-    {% if has_pls|string == 'True' %}
-    ,"performanceLevels": [
-      {
-        "assessmentReportingMethodDescriptor": "uri://act.org/AssessmentReportingMethodDescriptor#Score",
-        "maximumScore": "36",
-        "minimumScore": "22",
-        "performanceLevelDescriptor": "uri://act.org/PerformanceLevelDescriptor#At or Above Readiness Benchmark"
-      }
-    ]
-    {% endif %}
 
   }


### PR DESCRIPTION
This was a leftover from outdated code. This PL exists in the 'direct' integration ACT provides directly via Ed-Fi ODS connections, but there's no column for it in the files. We forgot to remove from objAssess template, so it will lead to missing Descriptor errors on lightbeam