### PR TITLE
Add SC state assessments' bundle metadata

### DIFF
--- a/assessments/EOCEP/_metadata.yaml
+++ b/assessments/EOCEP/_metadata.yaml
@@ -1,0 +1,13 @@
+display_name: "EOCEP"
+path: "assessments/EOCEP"
+valid_edfi: ">=3.0"
+report_resources: ["studentAssessments"]
+input_files:
+  - display_name: "Assessment data"
+    env_var: "INPUT_FILE"
+    is_required: true
+    file_type: ["csv", "txt"]
+input_params:
+  - display_name: "School Year"
+    env_var: "API_YEAR"
+    is_required: true

--- a/assessments/SC_Alternate_Assessment/_metadata.yaml
+++ b/assessments/SC_Alternate_Assessment/_metadata.yaml
@@ -1,0 +1,14 @@
+display_name: "SC Alternate"
+path: "assessments/SC_Alternate_Assessment"
+valid_edfi: ">=3.0"
+report_resources: ["studentAssessments"]
+input_files:
+  - display_name: "Assessment data"
+    env_var: "INPUT_FILE"
+    is_required: true
+    file_type: ["csv", "txt"]
+input_params:
+  - display_name: "School Year"
+    env_var: "API_YEAR"
+    is_required: true
+

--- a/assessments/SC_READY/_metadata.yaml
+++ b/assessments/SC_READY/_metadata.yaml
@@ -1,0 +1,13 @@
+display_name: "SC Ready"
+path: "assessments/SC_READY"
+valid_edfi: ">=3.0"
+report_resources: ["studentAssessments"]
+input_files:
+  - display_name: "Assessment data"
+    env_var: "INPUT_FILE"
+    is_required: true
+    file_type: ["csv", "txt"]
+input_params:
+  - display_name: "School Year"
+    env_var: "API_YEAR"
+    is_required: true


### PR DESCRIPTION
This PR responds to this [JIRA ticket](https://edanalytics.atlassian.net/browse/EDFIAL-178?actionerId=70121%3A7d902c33-c2e8-4302-b886-80171945234b&sourceType=assign).

Since example for this PR is [here](https://github.com/edanalytics/earthmover_edfi_bundles/blob/main/assessments/STAAR_Summative/_metadata.yaml), I have omitted "STUDENT_ID_NAME" as part of the `input_params`. However, we can add this param and set `is_required` to `TRUE` if necessary.