### PR TITLE
Fix: Student IDs package breaks when `EDFI_STUDENT_ID_TYPES` is empty

### DIFF
--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -110,7 +110,7 @@ sources:
   {% endif %}
     
 
-{% set edfi_student_id_types = "${EDFI_STUDENT_ID_TYPES},studentUniqueId".split(",") %}
+{% set edfi_student_id_types = (("${EDFI_STUDENT_ID_TYPES}" | trim) and "${EDFI_STUDENT_ID_TYPES}".split(",") or []) + ["studentUniqueId"] %}
 
 transformations:
   unpacked_edfi_roster:


### PR DESCRIPTION
When `EDFI_STUDENT_ID_TYPES` is empty, the student ID matching package should still try to match on `studentUniqueId`. However, due to the syntax of the jinja expression used there, it produces the list `["","studentUniqueId]`. When the empty ID type is used in the first iteration of the proceeding for loop, Earthmover throws an error