### PR TITLE
Feature/allow student ID matching against future enrollments

### DIFF
--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -75,10 +75,17 @@ sources:
               seoa.api_year,
               seoa.k_student,
               seoa.ed_org_id,
+              stg_ef3__students.student_unique_id,
               object_construct_keep_null('assigningOrganizationIdentificationCode', seo_ids.id_system,
                   'identificationCode', seo_ids.id_code) as stu_id_code,
+              -- in case of multiple years, dedupe by student unique ID
+              rank() over (
+                  partition by stg_ef3__students.student_unique_id, seoa.tenant_code, seoa.ed_org_id 
+                  order by seoa.api_year asc
+              ) as rank_by_year
           from ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__student_education_organization_associations seoa
-              left join  ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__stu_ed_org__identification_codes seo_ids on seoa.k_student=seo_ids.k_student
+              left join ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__stu_ed_org__identification_codes seo_ids on seoa.k_student=seo_ids.k_student
+              join ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__students on seoa.k_student = stg_ef3__students.k_student
           where seoa.tenant_code='${SNOWFLAKE_TENANT_CODE}'
           {% if "${ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS}" != "True" %}
               and seoa.api_year=${SNOWFLAKE_API_YEAR}
@@ -86,27 +93,16 @@ sources:
               and seoa.api_year >= ${SNOWFLAKE_API_YEAR}
           {% endif %}
       ),
+      ids_deduped as (
+          select *
+          from ids
+          where rank_by_year = 1
+      ),
       aggd_ids as (
           select
-              tenant_code, api_year, k_student, ed_org_id,
+              tenant_code, api_year, k_student, ed_org_id, student_unique_id,
               array_agg(stu_id_code) as stu_id_codes
-          from ids group by 1,2,3,4
-      ), aggd_ids_ranked as (
-          select stu.student_unique_id,
-          aggd_ids.tenant_code,
-          aggd_ids.api_year,
-          aggd_ids.k_student,
-          aggd_ids.ed_org_id,
-          aggd_ids.stu_id_codes,
-          {% if "${ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS}" != "True" %}
-          1 as rank_by_year
-          {% else %}
-          -- dedupe by student_unique_id if multiple years are allowed, taking 
-          -- minimum year
-          rank() over(partition by stu.student_unique_id, aggd_ids.ed_org_id order by aggd_ids.api_year asc) as rank_by_year
-          {% endif %}
-          from aggd_ids
-              join ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__students stu on aggd_ids.k_student=stu.k_student
+          from ids group by 1,2,3,4,5
       )
       select
           object_construct('educationOrganizationId', ed_org_id,
@@ -114,8 +110,7 @@ sources:
               'rel', 'LocalEducationAgency')) as "educationOrganizationReference",
           object_construct('studentUniqueId', student_unique_id) as "studentReference",
           stu_id_codes as "studentIdentificationCodes"
-      from aggd_ids_ranked
-      where rank_by_year = 1
+      from aggd_ids
     {% endif %}
   
   {% if "${MATCH_RATES_SOURCE_TYPE}"=="file" %}

--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -46,6 +46,7 @@ config:
           -- and assessment='${ASSESSMENT_BUNDLE}'
       )
     NO_MATCH_VALUE: __no_match__
+    ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS: false
     # and SNOWFLAKE_CONNECTION, SNOWFLAKE_TENANT_CODE, and SNOWFLAKE_API_YEAR (as above)
     # ----------------------------------------------------
 
@@ -79,24 +80,42 @@ sources:
           from ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__student_education_organization_associations seoa
               left join  ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__stu_ed_org__identification_codes seo_ids on seoa.k_student=seo_ids.k_student
           where seoa.tenant_code='${SNOWFLAKE_TENANT_CODE}'
+          {% if "${ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS}" != "True" %}
               and seoa.api_year=${SNOWFLAKE_API_YEAR}
+          {% else %}
+              and seoa.api_year >= ${SNOWFLAKE_API_YEAR}
+          {% endif %}
       ),
       aggd_ids as (
           select
               tenant_code, api_year, k_student, ed_org_id,
               array_agg(stu_id_code) as stu_id_codes
           from ids group by 1,2,3,4
+      ), aggd_ids_ranked as (
+          select stu.student_unique_id,
+          aggd_ids.tenant_code,
+          aggd_ids.api_year,
+          aggd_ids.k_student,
+          aggd_ids.ed_org_id,
+          aggd_ids.stu_id_codes,
+          {% if "${ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS}" != "True" %}
+          1 as rank_by_year
+          {% else %}
+          -- dedupe by student_unique_id if multiple years are allowed, taking 
+          -- minimum year
+          rank() over(partition by stu.student_unique_id, aggd_ids.ed_org_id order by aggd_ids.api_year asc) as rank_by_year
+          {% endif %}
+          from aggd_ids
+              join ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__students stu on aggd_ids.k_student=stu.k_student
       )
       select
           object_construct('educationOrganizationId', ed_org_id,
           'link', object_construct(
               'rel', 'LocalEducationAgency')) as "educationOrganizationReference",
-          object_construct('studentUniqueId', stu.student_unique_id) as "studentReference",
+          object_construct('studentUniqueId', student_unique_id) as "studentReference",
           stu_id_codes as "studentIdentificationCodes"
-      from aggd_ids
-          join ${SNOWFLAKE_EDU_STG_SCHEMA}.stg_ef3__students stu on aggd_ids.k_student=stu.k_student
-      where aggd_ids.tenant_code='${SNOWFLAKE_TENANT_CODE}'
-          and aggd_ids.api_year=${SNOWFLAKE_API_YEAR}
+      from aggd_ids_ranked
+      where rank_by_year = 1
     {% endif %}
   
   {% if "${MATCH_RATES_SOURCE_TYPE}"=="file" %}


### PR DESCRIPTION
Adds new optional parameter `ALLOW_MATCHING_ON_FUTURE_ENROLLMENTS`, which will pull in future enrollments for a student if no exact match on api_year is present when pulling an Ed-Fi roster from Snowflake. This breaks Ed-Fi rules but will solve a specific problem with enrollments erroneously deleted by the SIS where we need to sideload otherwise valid student-assessment records. 

The query is now a little more complex--if it's easier to read, I think we can put the old and new queries in separate if/else branches if we don't want to deal with in-query Jinja logic. In plain language, we can now have multiple rows in the roster for the same student_unique_id, which the query now dedupes by taking the lowest api_year. While deduping happens in the final xwalked roster in the `student_ids` bundle anyway, I'd still prefer to pipe less data into earthmover when possible for performance reasons. 

Tested against Horry SC-Alt 2023-24 sharded files:
- Confirmed that output without the new flag matches output from main.
- Confirmed that output with the new flag successfully matches 7 additional rows, which have future enrollments but are missing an enrollment in this year. 