### PR TITLE
Dev PSAT/SAT Updates

### DIFF
--- a/assessments/PSAT_SAT/_metadata.yaml
+++ b/assessments/PSAT_SAT/_metadata.yaml
@@ -1,4 +1,4 @@
-display_name: "PSAT_SAT"
+display_name: "PSAT/SAT"
 path: "assessments/PSAT_SAT"
 valid_edfi: ">=3.0"
 report_resources: ["studentAssessments"]

--- a/assessments/PSAT_SAT/_metadata.yaml
+++ b/assessments/PSAT_SAT/_metadata.yaml
@@ -14,5 +14,5 @@ input_params:
   - display_name: "Test Type"
     env_var: "TEST_TYPE"
     is_required: true
-    allowed_values: ["PSAT", "SAT"]
+    allowed_values: ["PSAT 8/9", "PSAT 10", "PSAT/NMSQT", "SAT"]
 descriptor_mapping_files: ["academicSubjectDescriptors.csv", "gradeLevelDescriptors.csv","assessmentCategoryDescriptors.csv"]

--- a/assessments/PSAT_SAT/earthmover.yaml
+++ b/assessments/PSAT_SAT/earthmover.yaml
@@ -264,8 +264,16 @@ transformations:
         columns:
           subject_json: "{%raw%}{{value.rstrip().rstrip(',')}}{%endraw%}"
 
-  grade_level_descriptors:
+  # Extra filter operation to remove undefined grade levels and ensure assessedGradeLevels array does not include nulls 
+  grade_level_descriptors__filtered:
     source: $sources.gradeLevelDescriptors
+    operations:
+      - operation: filter_rows
+        query: edfi_descriptor != ""
+        behavior: include
+
+  grade_level_descriptors:
+    source: $transformations.grade_level_descriptors__filtered
     operations:
       - operation: distinct_rows
         columns:


### PR DESCRIPTION
Just 2 changes here:

- Updating `display_name` in `metadata.yaml` from "PSAT_SAT" to "PSAT/SAT"
- Adding in transformation logic to filter out null values in the `gradeLevelDescriptors` seed before they are used in `assessments.jsont`