### PR TITLE
Update Access "ALTERNATE" Parameter to "FORMAT"

### DIFF
--- a/assessments/ACCESS/README.md
+++ b/assessments/ACCESS/README.md
@@ -16,12 +16,12 @@ earthmover run -c earthmover.yaml -p '{
 "OUTPUT_DIR": "output",
 "STUDENT_ID_NAME": "StateStudentID",
 "API_YEAR" : "2024",
-"ALTERNATE": "N" }'
+"FORMAT": "Standard" }'
 ```
 
 Runtime notes:
 - If you are processing an ACCESS file from 2021 or earlier, use `-c earthmover_2021.yaml`.
-- The <code>ALTERNATE</code> parameter must be set to "Y" for Alternate results files and "N" for Summative/Standard files.
+- The <code>FORMAT</code> parameter must be set to "Standard" for Summative/Standard files and "Alternate" for Alternate results files.
 
 Once you have inspected the output JSONL for issues, check the settings in `lightbeam.yaml` and transmit them to your Ed-Fi API with
 ```bash

--- a/assessments/ACCESS/_metadata.yaml
+++ b/assessments/ACCESS/_metadata.yaml
@@ -11,8 +11,8 @@ input_params:
   - display_name: "School Year"
     env_var: "API_YEAR"
     is_required: true
-  - display_name: "Alternate"
-    env_var: "ALTERNATE"
+  - display_name: "Format"
+    env_var: "FORMAT"
     is_required: true
-    allowed_values: ["Y", "N"]
+    allowed_values: ["Standard", "Alternate"]
 descriptor_mapping_files: ["academicSubjectDescriptors.csv", "assessmentCategoryDescriptors.csv", "gradeLevelDescriptors.csv"]

--- a/assessments/ACCESS/earthmover.yaml
+++ b/assessments/ACCESS/earthmover.yaml
@@ -13,7 +13,7 @@ config:
     STATE_FILE: ./runs.csv
     STUDENT_ID_NAME: 'edFi_studentUniqueID' # default to the column added by the apply_xwalk package of student ID xwalking feature
     POSSIBLE_STUDENT_ID_COLUMNS: 'UniqueDRCStudentID,StateStudentID,DistrictStudentID'
-    ALTERNATE: ''
+    FORMAT: 'Standard'
     DESCRIPTOR_NAMESPACE: uri://ed-fi.org
 
 sources:
@@ -23,7 +23,7 @@ sources:
     rename_cols: True
     columns:
       {% if "${API_YEAR}"|int > 2021 %}
-        {% if "${ALTERNATE}" == "N" %}
+        {% if "${FORMAT}" == "Standard" %}
         # Standard (post-2021)
         - StateNameAbbreviation
         - DistrictName
@@ -192,7 +192,7 @@ sources:
         - UniqueRecordID
         - DSRUpdated
         {% endif %}
-        {% if "${ALTERNATE}" == "Y" %}
+        {% if "${FORMAT}" == "Alternate" %}
         # Alternate (post-2021)
         - StateNameAbbreviation
         - DistrictName
@@ -377,7 +377,7 @@ sources:
         - DSRUpdated
         {% endif %}
       {% elif "${API_YEAR}"|int <= 2021 %}
-        {% if "${ALTERNATE}" == "N" %}
+        {% if "${FORMAT}" == "Standard" %}
         # Standard (pre-2021)
         - UniqueDRCStudentID
         - ReportedRecord
@@ -544,7 +544,7 @@ sources:
         - TierSelectionOverrideSpeaking
         - TierSelectionOverrideWriting
         {% endif %}
-        {% if "${ALTERNATE}" == "Y" %}
+        {% if "${FORMAT}" == "Alternate" %}
         # Alternate (pre-2021)
         - UniqueDRCStudentID
         - ReportedRecord
@@ -771,9 +771,14 @@ transformations:
           namespace: "uri://wida.wisc.edu/assess/access"
           defaultTestStartDateTime: "${API_YEAR}-04-01 00:00:00"
           school_year: ${API_YEAR}
-          alternate_assessment: ${ALTERNATE}
+          alternate_assessment:
+            {% if "${FORMAT}" == "Standard" %}
+              "N"
+            {% else %}
+              "Y"
+            {% endif %}
           assessment_identifier:
-            {% if "${ALTERNATE}" == "N" %}
+            {% if "${FORMAT}" == "Standard" %}
               "ACCESS"
             {% else %}
               "Alternate-ACCESS"


### PR DESCRIPTION
Changes include:

- Changing the `ALTERNATE` parameter accepting Y/N values to `FORMAT` accepting Standard/Alternate values. Default value is now 'Standard'
- Updating the `_metadata.yaml` file
- Updating the `README`