### PR TITLE
Ensure Latest Test Date is not empty 

### DIFF
--- a/assessments/PSAT_SAT/earthmover.yaml
+++ b/assessments/PSAT_SAT/earthmover.yaml
@@ -30,6 +30,8 @@ sources:
   input:
     file: ${INPUT_FILE}
     header_rows: 1
+    expect:
+      - LATEST_{{test}}_DATE != ''
     optional_fields:
       # reading/writing
       - LATEST_{{test}}_READING


### PR DESCRIPTION
In some input files, the LATEST_SAT_DATE (or LATEST_PSAT_DATE) column is present but values are empty. This does not raise an earthmover error, and instead these records are designate with the assessment identifier SAT_2400, often incorrectly.

This commit adds an `expect` to the input source, to cause an earthmover error when `LATEST_{{test}}_DATE != ''`,