### PR TITLE
CIRCLE fix for no-match student ID file header

### DIFF
--- a/assessments/CIRCLE/earthmover.yaml
+++ b/assessments/CIRCLE/earthmover.yaml
@@ -841,3 +841,11 @@ destinations:
     template: ./templates/performanceLevelDescriptors.jsont
     extension: jsonl
 
+  {# This overrides the no-match output header (if this bundle is being used with the `student_id` package) #}
+  {% if '${EDFI_ROSTER_SOURCE_TYPE}' == 'file' or '${EDFI_ROSTER_SOURCE_TYPE}' == 'snowflake' %}
+  input_no_student_id_match:
+    header: |
+      ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,RLN_v1 Results,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,PA_v2 Results,,,Syllabication_v2 Results,,,,,,,,,,Onset-Rime_v2 Results,,,,,,,,Alliteration_v2 Results,,,,,,,,,,Rhyming_I_v2 Results,,,,,,,,,,,,Letter_Sound_v1 Results,,,,,,,,,,,,,,Story_Retell_Comp_v1 Results,,,,,,,,,Early_Writing_v1 Results,,,,,,,,,,,,,RLNA_spa_v1 Results,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,PA_spa_v2 Results,,,Syllabication_spa_v2 Results,,,,,,,,,,Alliteration_spa_v2 Results,,,,,,,,,,Rhyming_I_spa_v2 Results,,,,,,,,,,,,Letter_Sound_spa_v1 Results,,,,,,,,,,,,,,Story_Retell_Comp_spa_v1 Results,,,,,,,,,Early_Writing_spa_v1 Results,,,,,,,,,,,,
+      ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+      {%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}
+  {% endif %}

--- a/assessments/CIRCLE/earthmover.yaml
+++ b/assessments/CIRCLE/earthmover.yaml
@@ -841,11 +841,17 @@ destinations:
     template: ./templates/performanceLevelDescriptors.jsont
     extension: jsonl
 
-  {# This overrides the no-match output header (if this bundle is being used with the `student_id` package) #}
+  {#
+    This overrides the no-match output header
+    (if this bundle is being used with the `student_id` package)
+    
+    Note that this relies on the order of packages in the the `student_id_wrapper`
+    package being {ASSSESSMENT} _then_ `student_id`, not vice-versa.
+  #}
   {% if '${EDFI_ROSTER_SOURCE_TYPE}' == 'file' or '${EDFI_ROSTER_SOURCE_TYPE}' == 'snowflake' %}
   input_no_student_id_match:
     header: |
-      ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,RLN_v1 Results,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,PA_v2 Results,,,Syllabication_v2 Results,,,,,,,,,,Onset-Rime_v2 Results,,,,,,,,Alliteration_v2 Results,,,,,,,,,,Rhyming_I_v2 Results,,,,,,,,,,,,Letter_Sound_v1 Results,,,,,,,,,,,,,,Story_Retell_Comp_v1 Results,,,,,,,,,Early_Writing_v1 Results,,,,,,,,,,,,,RLNA_spa_v1 Results,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,PA_spa_v2 Results,,,Syllabication_spa_v2 Results,,,,,,,,,,Alliteration_spa_v2 Results,,,,,,,,,,Rhyming_I_spa_v2 Results,,,,,,,,,,,,Letter_Sound_spa_v1 Results,,,,,,,,,,,,,,Story_Retell_Comp_spa_v1 Results,,,,,,,,,Early_Writing_spa_v1 Results,,,,,,,,,,,,
-      ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+      {%raw%}{% for i in range(__row_data__['__row_data__'].keys()|length-2) %},{% endfor %}{%endraw%}
+      {%raw%}{% for i in range(__row_data__['__row_data__'].keys()|length-2) %},{% endfor %}{%endraw%}
       {%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}
   {% endif %}

--- a/packages/student_id_wrapper/earthmover.yaml
+++ b/packages/student_id_wrapper/earthmover.yaml
@@ -11,6 +11,10 @@ config:
     EDFI_STUDENT_ID_TYPES: Local,School,District,State
 
 packages:
+  {#
+    DO NOT CHANGE the order of these packages - this would change which
+    takes precedence over which, and could break some bundles.
+  #}
   ${ASSESSMENT_BUNDLE}:
     git: https://github.com/edanalytics/earthmover_edfi_bundles.git
     branch: ${ASSESSMENT_BUNDLE_BRANCH}


### PR DESCRIPTION
This is a sort of hack, overriding the no-match student ID file header defined in the `student_id` package.

I tested it locally and it seems to work, but I'm not sure this is the best approach.

There are some complications we should discuss around what depends on what. I was under the impression that assessment bundles are always designed to be possible to run stand-alone (without the student ID package), but I'm not sure that's true for CIRCLE since it specifies `config.parameter_defaults.STUDENT_ID_NAME: 'edFi_studentUniqueID'` (which will not exist without the student ID package).

Anyway, this is just a draft for discussion.