### PR TITLE
Harden registry checker GH action

### DIFF
--- a/.github/workflows/check-registry.yaml
+++ b/.github/workflows/check-registry.yaml
@@ -27,11 +27,19 @@ jobs:
         run: |
           python -m pip install PyYAML
 
+      # prevent an attacker from maliciously modifying these scripts in their own PR and forcing them to execute
+      # Use the base versions instead
+      - name: Checkout trusted validator
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+
       - name: Generate registry.json
         run: |
-          python create-registry.py assessments --output /tmp/registry.generated.json
+          python trusted/create-registry.py assessments --output /tmp/registry.generated.json
           test -f /tmp/registry.generated.json || (echo "::error::failed to generate registry.json" && exit 1)
 
       - name: Compare registry.json to generated copy
         run: |
-          python .github/scripts/registry-diff.py registry.json /tmp/registry.generated.json
+          python trusted/.github/scripts/registry-diff.py registry.json /tmp/registry.generated.json

--- a/.github/workflows/check-registry.yaml
+++ b/.github/workflows/check-registry.yaml
@@ -8,7 +8,6 @@ on:
     paths:
       - "assessments/**/_metadata.yaml"
       - "registry.json"
-      - "create-registry.py"
 
 jobs:
   check-changes:


### PR DESCRIPTION
In light of recent supply chain attacks on Github Actions, I wanted to put another layer of insulation around the registry checker action. It now checks out the **base** version of the registry creation/validation scripts and runs those, instead of running whatever's on the PR branch. That prevents an attacker from forcing us to run a modified version of the script.

This means that legitimate modifications to these scripts require a manual review cycle before their effects are felt in the repo. That seems right to me anyway. As a result I removed `check-registry.py` from the list of files that trigger the action. It's moot since we wouldn't be running that changed version in any case.