### PR TITLE
distinct rows

### DIFF
--- a/assessments/FastBridge_English/earthmover.yaml
+++ b/assessments/FastBridge_English/earthmover.yaml
@@ -98,6 +98,7 @@ transformations:
       - operation: filter_rows
         query: season == ''
         behavior: exclude
+      - operation: distinct_rows
       - operation: pivot
         cols_by: cleaned_variable
         rows_by: [assessment, assessment_language, district, school, local_id, state_id, fast_id, grade, student_unique_id, season]

--- a/assessments/FastBridge_Math/earthmover.yaml
+++ b/assessments/FastBridge_Math/earthmover.yaml
@@ -98,6 +98,7 @@ transformations:
       - operation: filter_rows
         query: season == ''
         behavior: exclude
+      - operation: distinct_rows
       - operation: pivot
         cols_by: cleaned_variable
         rows_by: [assessment, assessment_language, district, school, local_id, state_id, fast_id, grade, student_unique_id, season]


### PR DESCRIPTION
When a row is empty, melt creates many dupes and this breaks the next transformation. This removes _exact_ duplicate records. This fixed the problem seen in Runway production.