### PR TITLE
Hotfix/kra grade

### DIFF
--- a/assessments/KRA/earthmover.yaml
+++ b/assessments/KRA/earthmover.yaml
@@ -258,15 +258,6 @@ transformations:
         join_type: inner
         left_key: assessmentIdentifier
         right_key: assessmentIdentifier
-      - operation: join
-        sources:
-          - $sources.gradeLevelDescriptors
-        join_type: inner
-        left_key: assessmentIdentifier
-        right_key: assessmentIdentifier
-      - operation: rename_columns
-        columns:
-          edfi_descriptor: gradeLevelDescriptor
       - operation: add_columns
         columns:
           SchoolYear: "{% raw %}{{School_Year|int}}{% endraw %}"
@@ -298,7 +289,6 @@ transformations:
           - administrationDate
           - SchoolYear
           - namespace
-          - gradeLevelDescriptor
           - OverallScore
           - OverallSem
           - PerformanceLevelDescriptor

--- a/assessments/KRA/seeds/gradeLevelDescriptors.csv
+++ b/assessments/KRA/seeds/gradeLevelDescriptors.csv
@@ -1,2 +1,3 @@
 assessmentIdentifier,edfi_descriptor
 KRA,uri://ed-fi.org/GradeLevelDescriptor#Prekindergarten
+KRA,uri://ed-fi.org/GradeLevelDescriptor#Kindergarten

--- a/assessments/KRA/templates/studentAssessments.jsont
+++ b/assessments/KRA/templates/studentAssessments.jsont
@@ -38,7 +38,6 @@
     "studentUniqueId": "{{studentUniqueId}}"
   },
   "administrationDate": "{{administrationDate}}",
-  "whenAssessedGradeLevelDescriptor": "{{gradeLevelDescriptor}}",
   {% if OverallScore is not none and OverallScore | length %}
   "scoreResults": [
     {%- for score in scores -%}


### PR DESCRIPTION
PR to address [EAPS 2148](https://edanalytics.atlassian.net/browse/EAPS-2148):

- Remove `whenAssessedGradelevelDescriptor` from template
- Add PK to `gradeLevelDescriptors` seed
- Remove `gradeLevelDescriptors` join in `earthmover.yaml`

Tested, should be good pending confirmation of KRA assessment structure.