### PR TITLE
Fix: accommodate ID types pulled from EDU

### DIFF
--- a/packages/student_ids/earthmover.yaml
+++ b/packages/student_ids/earthmover.yaml
@@ -128,7 +128,8 @@ transformations:
           studentUniqueId: '{%raw%}{% if studentReference is string %}{{fromjson(studentReference).studentUniqueId}}{% else %}{{studentReference.studentUniqueId}}{% endif %}{%endraw%}'
           # TODO: could maybe use a flatten operation for this?
           {% for id_code in "${EDFI_STUDENT_ID_TYPES}".split(",") %}
-          "{{id_code}}": "{% raw %}{% set codes = fromjson(studentIdentificationCodes) if studentIdentificationCodes is string else studentIdentificationCodes %}{% set ns = namespace(found='', done=false) %}{% for c in codes if not ns.done %}{% set code_name = (c.studentIdentificationSystemDescriptor.split('#'))[1] %}{% if code_name == '{% endraw %}{{ id_code }}{% raw %}' %}{% set ns.found = c['identificationCode'] %}{% set ns.done = true %}{% endif %}{% endfor %}{{ ns.found }}{% endraw %}"
+          # using split()[-1] here because it's possible for these ID types to have a full descriptor URI, and also for them to be bare
+          "{{id_code}}": "{% raw %}{% set codes = fromjson(studentIdentificationCodes) if studentIdentificationCodes is string else studentIdentificationCodes %}{% set ns = namespace(found='', done=false) %}{% for c in codes if not ns.done %}{% set code_name = (c.studentIdentificationSystemDescriptor.split('#'))[-1] %}{% if code_name == '{% endraw %}{{ id_code }}{% raw %}' %}{% set ns.found = c['identificationCode'] %}{% set ns.done = true %}{% endif %}{% endfor %}{{ ns.found }}{% endraw %}"
         {% endfor %}
       - operation: keep_columns
         columns:


### PR DESCRIPTION
We have assumed that roster files come from the ODS, where ID types have a full descriptor prefix (e.g. `ed-fi.org/IdentificationTypeDescriptor#State`). When we pull these ID types from EDU, the value is simply `State`, and we need to accommodate that case.