### PR TITLE
Set parameter default EDFI_DS_VERSION: 5

### DIFF
--- a/assessments/WI_Forward/earthmover.yaml
+++ b/assessments/WI_Forward/earthmover.yaml
@@ -12,6 +12,7 @@ config:
     STUDENT_ID_NAME: 'edFi_studentUniqueID' # default to the column added by the apply_xwalk package of student ID xwalking feature
     POSSIBLE_STUDENT_ID_COLUMNS: WISEID
     DESCRIPTOR_NAMESPACE: uri://ed-fi.org
+    EDFI_DS_VERSION: '5'
     REGENERATE_ASSESSMENT_SPEC: false
     API_YEAR: 2000 # set to arbitrary number
     INPUT_FILE: ''


### PR DESCRIPTION
This PR adds the `EDFI_DS_VERSION` variable to paramter defaults in `earthmover.yaml` to allow Jinja in `studentAssessments.jsont' to render properly. Tested locally with `sample_anonymized_file.csv`.