### PR TITLE
Fix/mvpa testID

### DIFF
--- a/assessments/MVPA/data/sample_anonymized_file.csv
+++ b/assessments/MVPA/data/sample_anonymized_file.csv
@@ -1,6 +1,6 @@
 TestID,LeaID,TestDate,SchoolYear,TestName,TestSchedule,TestAdmin,SchID,TchName,Period,StudentID,Fname,Lname,PercCorr,AchLev,AchLevExt,SuggNMark,SuggLMark
-XYZ,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 1,1,605000,First Name 1,Last Name 1,34.2857142857143,2,2-,60,D
-XYZ,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 2,1,605001,First Name 2,Last Name 2,37.1428571428571,2,2-,62,D
-XYZ,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 3,1,605002,First Name 3,Last Name 3,34.2857142857143,2,2-,60,D
-XYZ,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 4,1,605003,First Name 4,Last Name 4,22.8571428571429,1,1,53,F
-XYZ,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 5,2,605004,First Name 5,Last Name 5,17.1428571428571,1,1-,52,F
+scmat81900abcd,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 1,1,605000,First Name 1,Last Name 1,34.2857142857143,2,2-,60,D
+scmat81900abcd,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 2,1,605001,First Name 2,Last Name 2,37.1428571428571,2,2-,62,D
+scmat81900abcd,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 3,1,605002,First Name 3,Last Name 3,34.2857142857143,2,2-,60,D
+scmat81900abcd,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 4,1,605003,First Name 4,Last Name 4,22.8571428571429,1,1,53,F
+scmat81900abcd,District A,1900-01-01,2024-25,8th Grade Math,Year Round/Traditional,1st,School 1,Teacher 5,2,605004,First Name 5,Last Name 5,17.1428571428571,1,1-,52,F

--- a/assessments/MVPA/earthmover.yaml
+++ b/assessments/MVPA/earthmover.yaml
@@ -14,6 +14,11 @@ config:
     {%- else -%}{{title}}
     {%- endif -%}
     {%- endmacro %}
+
+    {%- macro get_assessment_identifier(test_id) -%}
+    MVPA_{{ test_id[2:6] | string}}
+    {%- endmacro -%}
+
   parameter_defaults:
     STUDENT_ID_NAME: 'edFi_studentUniqueID' # default to the column added by the apply_xwalk package of student ID xwalking feature
     POSSIBLE_STUDENT_ID_COLUMNS: StudentID
@@ -72,14 +77,17 @@ transformations:
         columns:
           studentAssessmentIdentifier: "{%raw%}{{ md5(studentAssessmentIdentifier) }}{%endraw%}"
           schoolYear: "{%raw%}{{ schoolYear[:4] | int +1 }}{%endraw%}"
+      - operation: add_columns
+        columns:
+          assessmentIdentifier: "{%raw%}{{ get_assessment_identifier(TestID) }}{%endraw%}"
       - operation: join
         sources:
           - $sources.assessments
         join_type: left
         left_keys:
-          - testName
+          - assessmentIdentifier
         right_keys:
-          - assessmentTitle
+          - assessmentIdentifier
 
   grade_level_descriptors:
     source: $sources.gradeLevelDescriptors


### PR DESCRIPTION
Small rewrite to change what drives the MVPA bundle:

- Extract `assessmentIdentifier` from the `TestID` column provided in MVPA inputs
- Change joins to rely on `assessmentIdentifier` instead of `assessmentTitle`
- Update sample file