### PR TITLE
STAAR & PreACT: fix bug that drops first row of fixed-width input files

### DIFF
--- a/assessments/PreACT/earthmover.yaml
+++ b/assessments/PreACT/earthmover.yaml
@@ -54,7 +54,6 @@ sources:
       end: end_index                      # required if `width` is not provided
       width: field_length                 # required if `start` or `end` is not provided
     type: fixedwidth               # required if `file` does not end with '.txt'
-    header_rows: 0
     {% endif %}
 
 transformations:

--- a/assessments/STAAR_Summative/earthmover.yaml
+++ b/assessments/STAAR_Summative/earthmover.yaml
@@ -58,7 +58,6 @@ sources:
   {% if "${INPUT_FILE}".endswith(".txt") %}
     file: ${INPUT_FILE}
     type: fixedwidth
-    header_rows: 0
     colspec_file: ./fwf_to_csv_xwalks/staar_summative_{{format}}fwf_xwalk_${API_YEAR}.csv
     colspec_headers:
       start: start_index


### PR DESCRIPTION
Turns out that `header_rows: 0` does not mean "there are no header rows"; it means "the header row is row 0 (i.e. the first row)". So Earthmover has been silently dropping the first row of these files