### PR TITLE
myIGDIs performance enhancement

### DIFF
--- a/assessments/myIGDIs/earthmover.yaml
+++ b/assessments/myIGDIs/earthmover.yaml
@@ -53,6 +53,10 @@ transformations:
           Init District Id: InitDistrictId
       - operation: melt
         id_vars: [SchoolYear, "District Name", "School Name", "Classroom Name", "Student's First Name", "Student's Last Name", InitDistrictId, "Student Id", studentUniqueId]
+      # Remove rows with empty or NaN melt_value (i.e. no data for that metric)
+      - operation: filter_rows
+        query: "melt_value == '' or melt_value != melt_value "
+        behavior: exclude
       # Parse the column name: {Assessment}/{Objective...}/{Window}/{Metric}
       # Español objectives contain '/' so we parse from both ends
       - operation: add_columns
@@ -69,6 +73,9 @@ transformations:
       - operation: filter_rows
         query: "metric in ['Score', 'Tier', 'AdministrationDate']"
         behavior: include
+      - operation: drop_columns
+        columns:
+          - melt_variable
       - operation: pivot
         cols_by: metric
         rows_by: [SchoolYear, "District Name", "School Name", "Classroom Name", "Student's First Name", "Student's Last Name", InitDistrictId, "Student Id", studentUniqueId, assessment, objective, TimeWindow]


### PR DESCRIPTION
JIRA ticket: https://edanalytics.atlassian.net/browse/EDFIAL-583

### PR Description
This PR implements similar fixes to the ones in https://github.com/edanalytics/earthmover_edfi_bundles/pull/332PR to minimize data explosion from the melt operation and improve overall runtime performance.

### Files Changed
earthmover.yaml: Drop columns irrelevant to final output, drop empty melt values

### QC done
run 900 rows of sample data with `edfi_testing_stack` was successful in ~3 minutes